### PR TITLE
[FIX] l10n_uy: be able to manage when stdnum is not defined

### DIFF
--- a/l10n_uy/demo/res_company_demo.xml
+++ b/l10n_uy/demo/res_company_demo.xml
@@ -4,7 +4,7 @@
     <record id="partner_uy" model="res.partner">
         <field name='name'>(UY) Company</field>
         <field name='l10n_latam_identification_type_id' ref='it_rut'/>
-        <field name='vat'>30111111118</field>
+        <field name='vat'>219999830019</field>
         <field name="street">Calle Falsa 123</field>
         <field name="city">Montevideo</field>
         <field name="country_id" ref="base.uy"/>

--- a/l10n_uy/models/res_partner.py
+++ b/l10n_uy/models/res_partner.py
@@ -1,5 +1,9 @@
-from odoo import models, api
-import stdnum.uy
+from odoo import models, api, _
+from odoo.exceptions import UserError
+import logging
+
+
+_logger = logging.getLogger(__name__)
 
 
 class ResPartner(models.Model):
@@ -21,4 +25,20 @@ class ResPartner(models.Model):
     def l10n_uy_check_vat(self, vat):
         """ Uruguayan VAT validation. TODO This need to be moved to module base_vat with name check_vat_uy when adding
         to Odoo Official """
-        return stdnum.uy.rut.validate(vat)
+        try:
+            import stdnum.uy
+            module = stdnum.uy.rut
+        except ImportError:
+            _logger.warning("Uruguayan VAT was not validated because stdnum.uy module is not available")
+            return True
+        try:
+            module.validate(vat)
+        except module.InvalidChecksum:
+            raise UserError(
+                _('The validation digit is not valid for "%s"') % self.l10n_latam_identification_type_id.name)
+        except module.InvalidLength:
+            raise UserError(_('Invalid length for "%s"') % self.l10n_latam_identification_type_id.name)
+        except module.InvalidFormat:
+            raise UserError(_('Only numbers allowed for "%s"') % self.l10n_latam_identification_type_id.name)
+        except Exception as error:
+            raise UserError(repr(error))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-stdnum>=1.16


### PR DESCRIPTION
ticket 38251
---

Local was working ok but we have a library problem in runbot, which is not available, add logic to manage the rut validation if the library is not defined.