### PR TITLE
[FIX] l10n_uy_account, l10n_uy_edi: change license

### DIFF
--- a/l10n_uy_account/__manifest__.py
+++ b/l10n_uy_account/__manifest__.py
@@ -6,7 +6,7 @@
     'name': 'Uruguay - Accounting',
     'author': 'ADHOC SA',
     'category': 'Localization',
-    'license': 'AGPL-3',
+    'license': 'LGPL-3',
     'version': '13.0.1.5.0',
     'depends': [
         'l10n_latam_invoice_document',

--- a/l10n_uy_edi/__manifest__.py
+++ b/l10n_uy_edi/__manifest__.py
@@ -6,7 +6,7 @@
     'name': 'Uruguay Electronic Invoice',
     'author': 'ADHOC SA',
     'category': 'Localization',
-    'license': 'AGPL-3',
+    'license': 'LGPL-3',
     'version': '13.0.1.6.0',
     'depends': [
         'l10n_uy_account',


### PR DESCRIPTION
Only needed to match with what we have in version 15.0 and to avoid conflicts on each FW from 13.0 to 15.0.