### PR TITLE
[FIX] l10n_uy_edi: get document_number

### DIFF
--- a/l10n_uy_edi/models/account_move.py
+++ b/l10n_uy_edi/models/account_move.py
@@ -619,7 +619,7 @@ class AccountMove(models.Model):
             if not related_cfe:
                 raise UserError(_('Para validar una ND/NC debe informar el Documento de Origen'))
             for k, related_cfe in enumerate(self._uy_found_related_invoice(), 1):
-                document_number = re.search(r"([A-Z]*)([0-9]*)", related_cfe.l10n_latam_document_number).groups()
+                document_number = re.findall(r"([A-Z])([0-9]*)", related_cfe.l10n_latam_document_number)[-1]
 
                 tpo_doc_ref = int(related_cfe.l10n_latam_document_type_id.code)
                 if not tpo_doc_ref:


### PR DESCRIPTION
ticket 52178

Now the document number of the related document
is correctly extracted, covering the relevant cases