### PR TITLE
[FIX] l10n_uy_edi: Patch reading company city

### DIFF
--- a/l10n_uy_edi/models/account_move.py
+++ b/l10n_uy_edi/models/account_move.py
@@ -361,7 +361,7 @@ class AccountMove(models.Model):
         }
 
     def _l10n_uy_validate_company_data(self):
-        for company in self.mapped('company_id'):
+        for company in self.sudo().mapped('company_id'):
             errors = []
 
             if not company.vat:


### PR DESCRIPTION
ticket 52796
---

Before posting the invoice we ensure that some fields in the company are
set because we need to enconde them in the xml we send to DGI. Doing
this we receivea access error related to write over res.company.

 WARNING runbss-2022-06-28 odoo.http: ("Lo sentimos, no tiene permiso
para modificar documentos de tipo 'Compañías' (res.company)

When consulting if the City field is set this calls to the
_compute_address method that tries to update the company fields.

  /home/odoo/src/odoo/odoo/addons/base/models/res_company.py(131)_compute_address()
-> company.update(company._get_company_address_fields(partner))

For users that does not have addmistrative permission will receive a
message not able to write over res.company model. This should have a
better solution from Odoo side but for know we need to fix it this
way to let non admin users to be able to generate