### PR TITLE
[FIX] l10n_uy_*: Mark modules as not migrated

### DIFF
--- a/l10n_uy_account/__manifest__.py
+++ b/l10n_uy_account/__manifest__.py
@@ -46,5 +46,5 @@
         # restore
         'demo/res_users_demo.xml',
     ],
-    'installable': True,
+    'installable': False,
 }

--- a/l10n_uy_currency_update/__manifest__.py
+++ b/l10n_uy_currency_update/__manifest__.py
@@ -39,7 +39,7 @@
         'data/res.currency.csv',
         'views/res_currency_views.xml',
     ],
-    'installable': True,
+    'installable': False,
     'auto_install': True,
     'application': False,
 }

--- a/l10n_uy_edi/__manifest__.py
+++ b/l10n_uy_edi/__manifest__.py
@@ -36,5 +36,5 @@
         'demo/res_company_demo.xml',
         'demo/account_journal_demo.xml',
     ],
-    'installable': True,
+    'installable': False,
 }

--- a/l10n_uy_edi_stock/__manifest__.py
+++ b/l10n_uy_edi_stock/__manifest__.py
@@ -17,7 +17,7 @@
         'data/l10n_latam.document.type.csv',
         'views/stock_picking_views.xml',
     ],
-    'installable': True,
+    'installable': False,
     'auto_install': False,
     'application': False,
     'license': 'LGPL-3',

--- a/l10n_uy_reports/__manifest__.py
+++ b/l10n_uy_reports/__manifest__.py
@@ -25,5 +25,5 @@
     ],
     'demo': [],
     'auto_install': True,
-    'installable': True,
+    'installable': False,
 }


### PR DESCRIPTION
Some FWs were merged yesterday marking modules as installable when they are not. Mark it as not installable in order to avoid error in runbot and we will start working on the modules migration