### PR TITLE
[FIX] l10n_uy_currency_update: BCU code AR

### DIFF
--- a/l10n_uy_currency_update/__manifest__.py
+++ b/l10n_uy_currency_update/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Uruguayan Currency Rate Update',
-    'version': '13.0.1.1.0',
+    'version': '13.0.1.2.0',
     'category': 'Localization/Uruguay',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/l10n_uy_currency_update/data/res.currency.csv
+++ b/l10n_uy_currency_update/data/res.currency.csv
@@ -6,7 +6,6 @@ base.AUD,105
 base.NZD,1490
 base.GBP,2700
 l10n_uy_account.UYI,9800
-base.ARS,500
 base.BRL,1001
 base.CLP,1300
 base.ZAR,1620


### PR DESCRIPTION
We have ARS currency twice in the list and this generates an error in new databases, setting wrongly the BCU code to 500 instead of 501

task 29103