### PR TITLE
[FIX] l10n_uy_edi: UCFE Enviroment not working

### DIFF
--- a/l10n_uy_edi/models/res_config_settings.py
+++ b/l10n_uy_edi/models/res_config_settings.py
@@ -37,7 +37,7 @@ class ResConfigSettings(models.TransientModel):
         raise UserError(_('Connection problems, this is what we get %s') % response)
 
     @api.onchange('l10n_uy_ucfe_env')
-    def onchange_ufce_env(self):
+    def uy_onchange_ufce_env(self):
         """ Update UCFE param with what we have when Environment change."""
 
         if self.l10n_uy_ucfe_env == 'production':
@@ -56,9 +56,9 @@ class ResConfigSettings(models.TransientModel):
 
     def set_values(self):
         super().set_values()
-        self.update_saved_param_data()
+        self.uy_update_saved_param_data()
 
-    def update_saved_param_data(self):
+    def uy_update_saved_param_data(self):
         """ If any of the ucfe params change then update the env_data values of the current selected environment"""
         # Create dictionary with the data
         import pprint


### PR DESCRIPTION
When we changed from the Production to the Testing environment this one was not working, the production params remain no matter what.

We have an onchange method that made this functionality possible but was not working. This was happening because we have the same method with the same name in saas_client_l10n_cl module, so our expected behavior was entirely overwritten by the one on l10n_cl.

Changing the methods name for UY resolves the problem now will work for either of the localizations