### PR TITLE
[REM] l10n_uy_edi: Remove NomComercial or Nombre Fantansia.

### DIFF
--- a/l10n_uy_edi/__manifest__.py
+++ b/l10n_uy_edi/__manifest__.py
@@ -7,7 +7,7 @@
     'author': 'ADHOC SA',
     'category': 'Localization',
     'license': 'LGPL-3',
-    'version': '15.0.1.3.0',
+    'version': '15.0.1.4.0',
     'depends': [
         'l10n_uy_account',
         'account_debit_note',

--- a/l10n_uy_edi/data/cfe_template.xml
+++ b/l10n_uy_edi/data/cfe_template.xml
@@ -25,7 +25,6 @@
                     <Emisor t-if="emisor">
                         <RUCEmisor t-esc="emisor['RUCEmisor']"/>
                         <RznSoc t-esc="emisor['RznSoc']"/>
-                        <NomComercial t-esc="emisor['NomComercial']"/>
                         <CdgDGISucur t-esc="emisor['CdgDGISucur']"/>
                         <DomFiscal t-esc="emisor['DomFiscal']"/>
                         <Ciudad t-esc="emisor['Ciudad']"/>

--- a/l10n_uy_edi/models/l10n_uy_cfe.py
+++ b/l10n_uy_edi/models/l10n_uy_cfe.py
@@ -382,7 +382,6 @@ class L10nUyCfe(models.AbstractModel):
 
         res.update(self._uy_cfe_A40_RUCEmisor())
         res.update(self._uy_cfe_A41_RznSoc())
-        res.update(self._uy_cfe_A42_NomComercial())
         res.update(self._uy_cfe_A47_CdgDGISucur())
         res.update(self._uy_cfe_A48_DomFiscal())
         res.update(self._uy_cfe_A49_Ciudad())
@@ -401,12 +400,6 @@ class L10nUyCfe(models.AbstractModel):
         self.ensure_one()
         res = self.company_id.name[:150]
         return {'RznSoc': res} if res else {}
-
-    def _uy_cfe_A42_NomComercial(self):
-        """ NOTA nosotros estamos reportando NomComercial pero Uruware no, ver si realmente es necesario o no si debemos quitarlo, revisar en DGI """
-        self.ensure_one()
-        res = self.company_id.name[:30]
-        return {'NomComercial': res} if res else {}
 
     def _uy_cfe_A47_CdgDGISucur(self):
         self.ensure_one()


### PR DESCRIPTION
We are not sending this information anymore, because if we do we are repeting the company name twice in the pdf report.

As far as we check there is not field that we can use rigth now in order to get nombre fantasia from the company.