### PR TITLE
[ADD] l10n_uy_edi: Preview and XML fields

### DIFF
--- a/l10n_uy_edi/__manifest__.py
+++ b/l10n_uy_edi/__manifest__.py
@@ -7,7 +7,7 @@
     'author': 'ADHOC SA',
     'category': 'Localization',
     'license': 'LGPL-3',
-    'version': '15.0.1.6.0',
+    'version': '15.0.1.7.0',
     'depends': [
         'l10n_uy_account',
         'account_debit_note',

--- a/l10n_uy_edi/models/l10n_uy_cfe.py
+++ b/l10n_uy_edi/models/l10n_uy_cfe.py
@@ -923,7 +923,6 @@ class L10nUyCfe(models.AbstractModel):
         cfe = cfe.unescape()
         cfe = '\n'.join([item for item in cfe.split('\n') if item.strip()])
 
-        self._l10n_uy_vaidate_cfe(cfe)
         return {'cfe_str': cfe}
 
     def _uy_get_cfe_lines(self):
@@ -1198,6 +1197,10 @@ class L10nUyCfe(models.AbstractModel):
         """ Be able to validate a cfe """
         self._l10n_uy_vaidate_cfe(self.sudo().l10n_uy_cfe_xml, raise_exception=True)
 
+    def action_l10n_uy_preview_xml(self):
+        """ Be able to show preview of the CFE to be send """
+        self.l10n_uy_cfe_xml = self._l10n_uy_create_cfe().get('cfe_str')
+
     def _dummy_dgi_validation(self):
         """ Only when we want to skip DGI validation in testing environment. Fill the DGI result  fields with dummy
         values in order to continue with the CFE validation without passing to DGI validations s"""
@@ -1224,6 +1227,7 @@ class L10nUyCfe(models.AbstractModel):
         for rec in self:
             now = datetime.utcnow()
             CfeXmlOTexto = rec._l10n_uy_create_cfe().get('cfe_str')
+            rec._l10n_uy_vaidate_cfe(CfeXmlOTexto)
             req_data = {
                 'Uuid': self._name + '-' + str(rec.id) + '_' + str(fields.Datetime.now()),  # TODO this need to be improve
                 'TipoCfe': int(rec.l10n_latam_document_type_id.code),

--- a/l10n_uy_edi/views/account_move_views.xml
+++ b/l10n_uy_edi/views/account_move_views.xml
@@ -50,14 +50,15 @@
                                         <field name="l10n_uy_dgi_barcode"/>
                                     </group>
                                 </page>
-                                <page string="XML CFE">
-                                    <button name="action_l10n_uy_validate_cfe" type="object" string="Validate CFE XML" class="oe_inline oe_link"/>
+                                <page string="XML CFE" groups="base.group_no_one">
+                                    <button name="action_l10n_uy_preview_xml" type="object" string="Preview" class="oe_inline oe_link" states="draft"/>
+                                    <button name="action_l10n_uy_validate_cfe" type="object" string="Validate" class="oe_inline oe_link" states="draft"/>
                                     <field name="l10n_uy_cfe_xml" nolabel="1" widget="ace"/>
                                 </page>
-                                <page string="XML Request">
+                                <page string="XML Request" groups="base.group_no_one">
                                     <field name="l10n_uy_dgi_xml_request" nolabel="1" widget="ace"/>
                                 </page>
-                                <page string="XML Response">
+                                <page string="XML Response" groups="base.group_no_one">
                                     <field name="l10n_uy_dgi_xml_response" nolabel="1" widget="ace"/>
                                 </page>
                             </notebook>


### PR DESCRIPTION
* Add Preview button visible in XML CFE, in order to quick preview the xml generated after a change we have made in data o code.
* Both Preview and Validate XML CFE buttons only visible in draft state
* Hide the pages related to XML, only show then in developer mode active, simpler for the user.