### PR TITLE
[FIX] l10n_uy_edi: traceback last document number

### DIFF
--- a/l10n_uy_edi/models/account_journal.py
+++ b/l10n_uy_edi/models/account_journal.py
@@ -1,4 +1,5 @@
-from odoo import models
+from odoo import _, models
+from odoo.exceptions import UserError
 
 
 class AccountJournal(models.Model):
@@ -14,6 +15,8 @@ class AccountJournal(models.Model):
         if self.l10n_uy_type in ['electronic'] and document_type.code != '000' and int(document_type.code) < 200:
             response = self.company_id._l10n_uy_ucfe_inbox_operation('660', {'TipoCfe': document_type.code})
             # response.Resp.Serie
+            if not response.Resp.NumeroCfe:
+                raise UserError(_('No tiene habilitado para emitir dicho documento, por favor revisar configuración de ') + document_type.display_name)
             res = int(response.Resp.NumeroCfe)
 
         # TODO Al consultar los valores de contigencia de la instancia me aparece error, por eso usamos los


### PR DESCRIPTION
task 35092
avoid traceback when using a document type that does not have been activated on uruwuare environment.