### PR TITLE
[FIX] l10n_uy_edi: runbot error

### DIFF
--- a/l10n_uy_edi/demo/res_company_demo.xml
+++ b/l10n_uy_edi/demo/res_company_demo.xml
@@ -9,6 +9,7 @@
 
     <record id="l10n_uy_account.company_uy" model="res.company">
         <field name='l10n_uy_dgi_house_code'>2</field>
+        <field name='l10n_uy_ucfe_env'>testing</field>
     </record>
 
 </odoo>


### PR DESCRIPTION
When intalling some demo data it fails because we do not have any UY environment defined.