### PR TITLE
[FIX] l10n_uy_edi: Cambiamos la asignacion de NomItem cuando no tenemos product_id

### DIFF
--- a/l10n_uy_edi/models/l10n_uy_cfe.py
+++ b/l10n_uy_edi/models/l10n_uy_cfe.py
@@ -1198,7 +1198,7 @@ class L10nUyCfe(models.AbstractModel):
             else:
                 raise UserError(_('It is not allowed to post an invoice (id: %s) with one or more invoice lines without product and without label.' % line.move_id.id))
 
-    def _uy_cfe_B8_DscItem(self, line):
+    def _uy_cfe_B8_DscItem(self, line, nomitem):
         """B8 Descripcion Adicional del ítem. Maximo 1000 caracteres
         """
         self.ensure_one()
@@ -1206,7 +1206,7 @@ class L10nUyCfe(models.AbstractModel):
         if line.product_id.l10n_uy_additional_info:
             res.append(line.product_id.l10n_uy_additional_info)
         if self._is_uy_inv_type_cfe():
-            if line.product_id.display_name != line.name:
+            if line.name and line.name != nomitem:
                 res.append(line.name)
         elif self._is_uy_remito_type_cfe():
             res.append(line.description_picking)
@@ -1310,7 +1310,7 @@ class L10nUyCfe(models.AbstractModel):
                              'DescuentoMonto': self._uy_cfe_B13_DescuentoMonto(line)
                             })
             item.update(self._uy_cfe_B11_PrecioUnitario(line, item.get('IndFact')))
-            item.update(self._uy_cfe_B8_DscItem(line))
+            item.update(self._uy_cfe_B8_DscItem(line, item.get('NomItem')))
             res.append(item)
 
         return res


### PR DESCRIPTION
Ticket: 78560
Cuando el cliente crea lineas sin productos, el NomItem que se setea es el mismo que la descripcion por lo tanto se duplica, con este cambio nos evitamos este problema.