### PR TITLE
[FIX] l10n_uy_account: remove depend to account_withholding

### DIFF
--- a/l10n_uy_account/__manifest__.py
+++ b/l10n_uy_account/__manifest__.py
@@ -7,14 +7,13 @@
     'author': 'ADHOC SA',
     'category': 'Localization',
     'license': 'LGPL-3',
-    'version': "16.0.1.4.0",
+    'version': "16.0.1.5.0",
     'depends': [
         'l10n_latam_invoice_document',
         'l10n_latam_base',
 
         # TODO move it to l10n_uy_ux once we have it?
         'l10n_latam_check',
-        'account_withholding',
     ],
     'data': [
         'data/l10n_latam.document.type.csv',


### PR DESCRIPTION
We really do not need it and is given us trouble on migration of clients to version 17.0 (account_withholding was rename to 1l0n_ar_withholding and now depends on l10n_ar): some pure UY clients now are installing AR loc by mistake.

Ticket 41724