### PR TITLE
[ADD] l10n_uy_edi: CN/DN wo accepted related doc

### DIFF
--- a/l10n_uy_edi/models/account_move.py
+++ b/l10n_uy_edi/models/account_move.py
@@ -105,8 +105,6 @@ class AccountMove(models.Model):
             res = self.reversed_entry_id
         elif self.l10n_latam_document_type_id.internal_type == 'debit_note':
             res = self.debit_origin_id
-        if res and res.l10n_uy_cfe_state != 'accepted':
-            raise UserError(_('El comprobante que estas anexando como referencia no es un comprobante valido para DGI(aceptado)'))
         return res
 
     def _is_uy_cfe(self):


### PR DESCRIPTION
We delete a constraint that requires to have an accepted original document in order to be able to generate CN or DN. This is not actually needed:

1. if there is a problem with the original document then DGI response will let us know and will reject our DN/CN
2. In the case I create an invoice, and immediately found an error we can now generate the credit note: not need to wait the invoices has been process. They will process together by the cron.
3. For the case that we need to generate DN and CN where the original related document was generate with other sofware (for example a DN or CN from an old invoice genrated in previos sofware provider) without this constraint is possible.