### PR TITLE
[FIX] l10n_uy_ux: Re-Print PDF on demo mode

### DIFF
--- a/l10n_uy_ux/models/account_move.py
+++ b/l10n_uy_ux/models/account_move.py
@@ -171,7 +171,20 @@ class AccountMove(models.Model):
     def action_l10n_uy_get_pdf(self):
         """ boton que permite descargar nuevamente el pdf de uruware y adjuntarlo a odoo """
         self.ensure_one()
-        pdf_result = self._l10n_uy_edi_get_pdf()
+
+        # Si estamos intentado forzar el volver a crear el PDF y estamos en ambiente DEMO simplemente generamos
+        # el reporte no legal (asi no intenta conectarse a Uruware y salta error)
+        if self.company_id.l10n_uy_edi_ucfe_env == "demo":
+            self.env['account.move.send'].with_context(active_model='account.move', active_ids=self.ids).create({
+                'checkbox_send_mail': False, 'checkbox_download': True}).action_send_and_print()
+            pdf_result = {"pdf_file": self.env["ir.attachment"].search([
+                ("res_model", "=", "account.move"),
+                ("res_id", "=", self.id),
+                ("res_field", "=", "invoice_pdf_report_file")
+            ])}
+        else:
+            pdf_result = self._l10n_uy_edi_get_pdf()
+
         if pdf_file := pdf_result.get("pdf_file"):
             # make sure latest PDF shows to the right of the chatter
             pdf_file.register_as_main_attachment(force=True)


### PR DESCRIPTION
The PDF is generated when doing send and print and the logic is already solved to skip real PDF generation on demo mode.

However, in this module we have an extra method ro Re-generate the PDF and attached to the invoice.

If we try to do this in demo mode will fail because it tries to connecto to uruware wo real elements. With this change if we are in demo mode re-print will re generate odoo PDF and will not retrieve any traceback error.

Current behavior 
```
RPC_ERROR
Odoo Server Error
Traceback (most recent call last):
  File "/data/build/adhoc-cicd-odoo-odoo/odoo/http.py", line 1783, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/data/build/adhoc-cicd-odoo-odoo/odoo/service/model.py", line 133, in retrying
    result = func()
  File "/data/build/adhoc-cicd-odoo-odoo/odoo/http.py", line 1810, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/data/build/adhoc-cicd-odoo-odoo/odoo/http.py", line 2014, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/data/build/adhoc-cicd-odoo-odoo/addons/website/models/ir_http.py", line 235, in _dispatch
    response = super()._dispatch(endpoint)
  File "/data/build/adhoc-cicd-odoo-odoo/odoo/addons/base/models/ir_http.py", line 225, in _dispatch
    result = endpoint(**request.params)
  File "/data/build/adhoc-cicd-odoo-odoo/odoo/http.py", line 757, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/data/build/adhoc-cicd-odoo-odoo/addons/web/controllers/dataset.py", line 28, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "/data/build/adhoc-cicd-odoo-odoo/addons/web/controllers/dataset.py", line 20, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/data/build/adhoc-cicd-odoo-odoo/odoo/api.py", line 468, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/data/build/adhoc-cicd-odoo-odoo/odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/data/build/ingadhoc-uruguay/l10n_uy_ux/models/account_move.py", line 174, in action_l10n_uy_get_pdf
    pdf_result = self._l10n_uy_edi_get_pdf()
  File "/data/build/adhoc-cicd-odoo-enterprise/l10n_uy_edi/models/account_move.py", line 655, in _l10n_uy_edi_get_pdf
    result = self.l10n_uy_edi_document_id._get_pdf()
  File "/data/build/adhoc-cicd-odoo-enterprise/l10n_uy_edi/models/l10n_uy_edi_document.py", line 233, in _get_pdf
    result = self._ucfe_query(report_params, req_data)
  File "/data/build/adhoc-cicd-odoo-enterprise/l10n_uy_edi/models/l10n_uy_edi_document.py", line 397, in _ucfe_query
    return self._ucfe_ws_call(company, "query", method, **req_data)
  File "/data/build/adhoc-cicd-odoo-enterprise/l10n_uy_edi/models/l10n_uy_edi_document.py", line 404, in _ucfe_ws_call
    if not url.endswith("?wsdl"):
AttributeError: 'bool' object has no attribute 'endswith'

The above server error caused the following client error:
RPC_ERROR: Odoo Server Error
    RPC_ERROR
        at makeErrorFromResponse (https://114463-17-0-all.runbot.adhoc.com.ar/web/assets/18f8651/web.assets_web.min.js:2918:163)
        at XMLHttpRequest.<anonymous> (https://114463-17-0-all.runbot.adhoc.com.ar/web/assets/18f8651/web.assets_web.min.js:2922:13)

```
