### PR TITLE
[FIX] l10n_uy_ux: Certificate use new odoo model

### DIFF
--- a/l10n_uy_ux/__manifest__.py
+++ b/l10n_uy_ux/__manifest__.py
@@ -8,9 +8,10 @@
     "category": "Localization",
     "countries": ["uy"],
     "license": "LGPL-3",
-    "version": "18.0.1.1.0",
+    "version": "18.0.1.2.0",
     "depends": [
         "l10n_uy_edi",
+        "certificate",
     ],
     "data": [
         "data/l10n_latam.document.type.csv",

--- a/l10n_uy_ux/i18n/es.po
+++ b/l10n_uy_ux/i18n/es.po
@@ -186,12 +186,6 @@ msgid "DGI Certificate"
 msgstr ""
 
 #. module: l10n_uy_ux
-#: model:ir.model.fields,field_description:l10n_uy_ux.field_res_company__l10n_uy_dgi_crt_fname
-#: model:ir.model.fields,field_description:l10n_uy_ux.field_res_config_settings__l10n_uy_dgi_crt_fname
-msgid "DGI Certificate name"
-msgstr ""
-
-#. module: l10n_uy_ux
 #: model:ir.model.fields,field_description:l10n_uy_ux.field_res_partner_update_from_padron_uy_field__display_name
 #: model:ir.model.fields,field_description:l10n_uy_ux.field_res_partner_update_from_padron_uy_wizard__display_name
 msgid "Display Name"
@@ -407,12 +401,6 @@ msgstr ""
 #. module: l10n_uy_ux
 #: model_terms:ir.ui.view,arch_db:l10n_uy_ux.view_move_form_inherit_l10n_uy_edi
 msgid "Preview"
-msgstr ""
-
-#. module: l10n_uy_ux
-#: model:ir.model.fields,field_description:l10n_uy_ux.field_res_company__l10n_uy_dgi_crt_pass
-#: model:ir.model.fields,field_description:l10n_uy_ux.field_res_config_settings__l10n_uy_dgi_crt_pass
-msgid "Private Password"
 msgstr ""
 
 #. module: l10n_uy_ux

--- a/l10n_uy_ux/i18n/es_419.po
+++ b/l10n_uy_ux/i18n/es_419.po
@@ -160,16 +160,10 @@ msgid "DGI / Uruware"
 msgstr ""
 
 #. module: l10n_uy_ux
-#: model:ir.model.fields,field_description:l10n_uy_ux.field_res_company__l10n_uy_dgi_crt
-#: model:ir.model.fields,field_description:l10n_uy_ux.field_res_config_settings__l10n_uy_dgi_crt
+#: model:ir.model.fields,field_description:l10n_uy_ux.field_res_company__l10n_uy_dgi_crt_id
+#: model:ir.model.fields,field_description:l10n_uy_ux.field_res_config_settings__l10n_uy_dgi_crt_id
 msgid "DGI Certificate"
 msgstr "Certificado DGI"
-
-#. module: l10n_uy_ux
-#: model:ir.model.fields,field_description:l10n_uy_ux.field_res_company__l10n_uy_dgi_crt_fname
-#: model:ir.model.fields,field_description:l10n_uy_ux.field_res_config_settings__l10n_uy_dgi_crt_fname
-msgid "DGI Certificate name"
-msgstr "Nombre del certificado DGI"
 
 #. module: l10n_uy_ux
 #: model:ir.model.fields,field_description:l10n_uy_ux.field_res_partner_update_from_padron_uy_field__display_name
@@ -425,12 +419,6 @@ msgid "Preview"
 msgstr "Previsualización"
 
 #. module: l10n_uy_ux
-#: model:ir.model.fields,field_description:l10n_uy_ux.field_res_company__l10n_uy_dgi_crt_pass
-#: model:ir.model.fields,field_description:l10n_uy_ux.field_res_config_settings__l10n_uy_dgi_crt_pass
-msgid "Private Password"
-msgstr "Contraseña Privada"
-
-#. module: l10n_uy_ux
 #: model:ir.model,name:l10n_uy_ux.model_ir_actions_report
 msgid "Report Action"
 msgstr "Reportar acción"
@@ -496,8 +484,8 @@ msgid "There are no more partners to update for this request..."
 msgstr "No hay más contactos para actualizar para esta solicitud..."
 
 #. module: l10n_uy_ux
-#: model:ir.model.fields,help:l10n_uy_ux.field_res_company__l10n_uy_dgi_crt
-#: model:ir.model.fields,help:l10n_uy_ux.field_res_config_settings__l10n_uy_dgi_crt
+#: model:ir.model.fields,help:l10n_uy_ux.field_res_company__l10n_uy_dgi_crt_id
+#: model:ir.model.fields,help:l10n_uy_ux.field_res_config_settings__l10n_uy_dgi_crt_id
 msgid ""
 "This certificate lets us connect to DGI to validate electronic invoice. "
 "Please upload here the DGI certificate in PEM format."

--- a/l10n_uy_ux/models/__init__.py
+++ b/l10n_uy_ux/models/__init__.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import account_journal
 from . import account_move
+from . import certificate_certificate
 from . import ir_actions_report
 from . import l10n_latam_document_type
 from . import l10n_uy_addenda

--- a/l10n_uy_ux/models/certificate_certificate.py
+++ b/l10n_uy_ux/models/certificate_certificate.py
@@ -1,0 +1,12 @@
+from odoo import _, api, models
+from odoo.exceptions import ValidationError
+
+
+class Certificate(models.Model):
+    _inherit = 'certificate.certificate'
+
+    @api.constrains("content", "pkcs12_password")
+    def _l10n_uy_check_private_key(self):
+        """ For Uruguay we will need always the pkcs12 private key """
+        if self.company_id.country_code == "UY" and not self.pkcs12_password:
+            raise ValidationError(_("Please set the Certificate Password"))

--- a/l10n_uy_ux/models/res_company.py
+++ b/l10n_uy_ux/models/res_company.py
@@ -17,9 +17,8 @@ class ResCompany(models.Model):
 
     l10n_uy_report_params = fields.Char()
 
-    # DGI informative files
-    l10n_uy_dgi_crt = fields.Binary(
-        "DGI Certificate", groups="base.group_system", help="This certificate lets us"
-        " connect to DGI to validate electronic invoice. Please upload here the DGI certificate in PEM format.")
-    l10n_uy_dgi_crt_fname = fields.Char("DGI Certificate name")
-    l10n_uy_dgi_crt_pass = fields.Char("Private Password")
+    # DGI informative fields.
+    l10n_uy_dgi_crt_id = fields.Many2one(
+        "certificate.certificate", "DGI Certificate", groups="base.group_system",
+        help="This certificate lets us connect to DGI to validate electronic invoice."
+        " Please upload here the DGI certificate in PEM format and its password.")

--- a/l10n_uy_ux/models/res_config_settings.py
+++ b/l10n_uy_ux/models/res_config_settings.py
@@ -9,9 +9,7 @@ class ResConfigSettings(models.TransientModel):
 
     _inherit = "res.config.settings"
 
-    l10n_uy_dgi_crt = fields.Binary(related="company_id.l10n_uy_dgi_crt", readonly=False)
-    l10n_uy_dgi_crt_fname = fields.Char(related="company_id.l10n_uy_dgi_crt_fname", readonly=False)
-    l10n_uy_dgi_crt_pass = fields.Char(related="company_id.l10n_uy_dgi_crt_pass", readonly=False)
+    l10n_uy_dgi_crt_id = fields.Many2one(related="company_id.l10n_uy_dgi_crt_id", readonly=False)
     l10n_uy_report_params = fields.Char(related="company_id.l10n_uy_report_params", readonly=False)
 
     @api.onchange("l10n_uy_edi_ucfe_env")

--- a/l10n_uy_ux/views/res_config_settings_view.xml
+++ b/l10n_uy_ux/views/res_config_settings_view.xml
@@ -18,14 +18,8 @@
                 <setting id="uy_dgi" string="DGI" company_dependent="1" help="Informative fields">
                     <div class="content-group">
                         <div class="row">
-                            <!-- We need this to be able to save correctly the file name -->
-                            <field name="l10n_uy_dgi_crt_fname" invisible="1" force_save="1"/>
-                            <label for="l10n_uy_dgi_crt" string="Certificate" class="col-lg-3 o_light_label"/>
-                            <field name="l10n_uy_dgi_crt" widget="binary" filename="l10n_uy_dgi_crt_fname" help="Here need to upload the file with the Digital Certificate to operate in DGI"/>
-                        </div>
-                        <div class="row">
-                            <label for="l10n_uy_dgi_crt_pass" class="col-lg-3 o_light_label"/>
-                            <field name="l10n_uy_dgi_crt_pass" password="True"/>
+                            <label for="l10n_uy_dgi_crt_id" string="Certificate" class="o_light_label col-lg-3"/>
+                            <field name="l10n_uy_dgi_crt_id" help="Uplad Certificate and Password"/>
                         </div>
                     </div>
                 </setting>


### PR DESCRIPTION
Instead of having a binary and a private key fields, use the new Odoo module to save the certificate info.