### PR TITLE
[FIX] l10n_uy_edi: "Lock Posted Entries with Hash" field on uy electronic journals.

### DIFF
--- a/l10n_uy_edi/__manifest__.py
+++ b/l10n_uy_edi/__manifest__.py
@@ -7,12 +7,13 @@
     'author': 'ADHOC SA',
     'category': 'Localization',
     'license': 'LGPL-3',
-    'version': "16.0.1.10.0",
+    'version': "16.0.1.11.0",
     'depends': [
         'l10n_uy_account',
         'account_debit_note',
     ],
     'data': [
+        'views/account_journal_view.xml',
         'views/res_config_settings_view.xml',
         'views/account_move_views.xml',
         'views/res_company_views.xml',

--- a/l10n_uy_edi/views/account_journal_view.xml
+++ b/l10n_uy_edi/views/account_journal_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+  <record id="view_account_journal_form" model="ir.ui.view">
+        <field name="model">account.journal</field>
+        <field name="name">account.journal.form</field>
+        <field name="inherit_id" ref="l10n_latam_invoice_document.view_account_journal_form"/>
+        <field name="arch" type="xml">
+            <!-- El campo restrict_mode_hash_table en True en 18 no permite que se validen facturas de cliente electrónicas en localización uruguaya. Esto ya fue reportado a Odoo. Lo mantenemos invisible en 16 para que no haya problemas al migrar a 18 si es que en 16 tenían dicho campo establecido. Se podría borrar esto cuando odoo solucione el problema en 18 -->
+            <field name="restrict_mode_hash_table" position="attributes">
+                <attribute name="attrs">{'invisible': [('country_code', '=', 'UY'), ('type', '=', 'sale'), ('l10n_uy_type', '=', 'electronic')]}</attribute>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Ticket: 87804
El campo restrict_mode_hash_table en True en 18 no permite que se validen facturas de cliente electrónicas en localización uruguaya. Esto ya fue reportado a Odoo. Lo mantenemos invisible en 16 para que no haya problemas al migrar a 18.