### PR TITLE
[FIX] l10n_uy_ux: extra params can be sent simultaneously

### DIFF
--- a/l10n_uy_ux/models/l10n_uy_edi_document.py
+++ b/l10n_uy_ux/models/l10n_uy_edi_document.py
@@ -77,7 +77,8 @@ class L10nUyEdiDocument(models.Model):
 
         if nombreParametros and valoresParametros:
             return "ObtenerPdfConParametros", {
-                'nombreParametros': nombreParametros, 'valoresParametros': valoresParametros}
+                'nombreParametros': {"string": nombreParametros},
+                'valoresParametros': {"string": valoresParametros}}
         return super()._get_report_params()
 
     # Metodos nuevos


### PR DESCRIPTION
Fixed the way of sending the extra params to Uruware so we can send both simultaneously. Without the "string": param dictionary, when we sent the request only one param was taken into account.