### PR TITLE
[FIX] l10n_uy_account: VAT validation

### DIFF
--- a/l10n_uy_account/models/res_partner.py
+++ b/l10n_uy_account/models/res_partner.py
@@ -13,73 +13,15 @@ class ResPartner(models.Model):
 
     @api.constrains('vat', 'l10n_latam_identification_type_id')
     def check_vat(self):
-        """ Uruguayan VAT validation. : Add validation of Uruguayan RUT removing the logic of odoo that requires prefix
-        of the contry code CC## in the vat number
-
-        Also add the validation of UY document types RUC/RUT (vat), CI and NIE
-
-        TODO This need to be moved to module base_vat with name check_vat_uy when adding to Odoo Official """
-        # NOTE by the moment we include the RUT (VAT UY) validation also here because we extend the messages
-        # errors to be more friendly to the user. In a future when Odoo improve the base_vat message errors
-        # we can change this method and use the base_vat.check_vat_uy method.
-        l10n_uy_partners = self.filtered(lambda x: x.l10n_latam_identification_type_id.l10n_uy_dgi_code)
-        for partner in l10n_uy_partners:
-            msg = partner._l10n_uy_check_document_number_error()
-            if msg:
-                raise ValidationError(msg)
-        return super(ResPartner, self - l10n_uy_partners).check_vat()
-
-    @api.onchange('vat')
-    def _onchange_document_number(self):
-        msg = self._l10n_uy_check_document_number_error()
-        if msg:
-            return {'warning': {'title': "Warning", 'message': msg, 'type': 'notification'}}
-
-    def _l10n_uy_check_document_number_error(self):
-        """ Return False if everything ok, return a message if there is an error in the doc number """
-        self.ensure_one()
-        if not self.vat:
-            return False
-        msg = False
-        if self.l10n_latam_identification_type_id.is_vat:
-            valid, msg = self._l10n_uy_check_ruc_rut(self.vat)
-            if not valid:
-                msg = _('Not a valid RUT/RUC: %s') % msg
+        # EXTENDS: base_vat
+        """ Add the validation of other UY document types: CI and NIE """
         ci_nie_types = self.env.ref('l10n_uy_account.it_nie') | self.env.ref('l10n_uy_account.it_ci')
-        if self.l10n_latam_identification_type_id in ci_nie_types:
-            valid = self._l10n_uy_check_nie_ci()
+        ci_nie_partners = self.filtered(lambda x: x.vat and x.l10n_latam_identification_type_id in ci_nie_types)
+        for partner in ci_nie_partners:
+            valid = partner._l10n_uy_check_nie_ci()
             if not valid:
-                msg = _('Not a valid CI/NIE')
-        return msg
-
-    @api.model
-    def _l10n_uy_check_ruc_rut(self, vat):
-        """ Check if the VAT is valid if. Return tuple:
-            (True, False)   if valid vat number
-            (False, msg)    if NOT valid number, and the msg with the error
-        """
-        if not self.vat:
-            return True, False
-
-        msg = False
-        try:
-            import stdnum.uy
-            module = stdnum.uy.rut
-            res = None
-        except ImportError:
-            _logger.info("Uruguayan VAT was not validated because stdnum.uy module is not available")
-            return True, False
-        try:
-            res = module.validate(vat)
-        except module.InvalidChecksum:
-            msg = _('The validation digit is not valid for "%s"') % self.l10n_latam_identification_type_id.name
-        except module.InvalidLength:
-            msg = _('Invalid length for "%s"') % self.l10n_latam_identification_type_id.name
-        except module.InvalidFormat:
-            msg = _('Only numbers allowed for "%s"') % self.l10n_latam_identification_type_id.name
-        except Exception as error:
-            msg = repr(error)
-        return bool(res), msg
+                raise ValidationError(_('Not a valid CI/NIE'))
+        return super(ResPartner, self - ci_nie_partners).check_vat()
 
     def _l10n_uy_check_nie_ci(self):
         """ algorithm to check if a NIE or CI number is a valid one """
@@ -117,6 +59,6 @@ class ResPartner(models.Model):
             return False
 
     def _is_rut(self):
+        """ Check if the partner has a valid RUT """
         self.ensure_one()
-        return True if self.l10n_latam_identification_type_id.l10n_uy_dgi_code == '2' and self.vat and \
-            self._l10n_uy_check_ruc_rut(self.vat)[0] else False
+        return True if self.l10n_latam_identification_type_id.l10n_uy_dgi_code == '2' and self.vat else False


### PR DESCRIPTION
In this module we extend the base vat validation to addmore info about the RUT number (invalid lenght, invalid check number, etc)

We remove this logic because we can not use the stdnum lib to get this info. Now we are using regular Odoo  base  vat moduñe validations that are compatible with new RUT starting with 22 number

Ticket 91574