### PR TITLE
[FIX]l10n_uy_ux: refactor partner data demo to comply with odoo vat restrictions

### DIFF
--- a/l10n_uy_ux/__manifest__.py
+++ b/l10n_uy_ux/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Localization",
     "countries": ["uy"],
     "license": "LGPL-3",
-    "version": "18.0.1.7.0",
+    "version": "18.0.1.8.0",
     "depends": [
         "l10n_uy_edi",
         "certificate",

--- a/l10n_uy_ux/demo/res_partner_demo.xml
+++ b/l10n_uy_ux/demo/res_partner_demo.xml
@@ -1,18 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-
-    <record id="res_partner_padron_dgi" model="res.partner">
-        <field name="name">Test Padron DGI</field>
-        <field name="l10n_latam_identification_type_id" ref="l10n_uy.it_rut"/>
-        <field name="company_id" ref="base.demo_company_uy"/>
-    </record>
-
     <record id="res_partner_padron_dgi_1" model="res.partner">
         <field name="name">Test Padron 1: Ejemplo para actualizar datos</field>
         <field name="ref">Test Padron 1: Ejemplo para actualizar datos</field>
         <field name="l10n_latam_identification_type_id" ref="l10n_uy.it_rut"/>
         <field name="vat">219000090011</field>
-        <field name="parent_id" ref="res_partner_padron_dgi"/>
         <field name="company_id" ref="base.demo_company_uy"/>
         <field name="is_company" eval="True"/>
     </record>
@@ -22,7 +14,6 @@
         <field name="ref">Test Padron 2: Ejemplo para actualizar datos</field>
         <field name="l10n_latam_identification_type_id" ref="l10n_uy.it_rut"/>
         <field name="vat">219999820013</field>
-        <field name="parent_id" ref="res_partner_padron_dgi"/>
         <field name="company_id" ref="base.demo_company_uy"/>
         <field name="is_company" eval="True"/>
     </record>
@@ -31,10 +22,9 @@
         <value model="res.partner" eval="obj().search([('vat', '=', '219999830019'), ('company_id', '=', ref('base.demo_company_uy'))]).ids"/>
         <value eval="{
             'name': 'Test Padron 3 - Ejemplo para actualizar datos',
+            'ref': 'Test Padron 3 - Ejemplo para actualizar datos',
             'l10n_latam_identification_type_id': ref('l10n_uy.it_rut'),
             'vat': '219999830019',
-            'is_company': True,
-            'parent_id': ref('res_partner_padron_dgi')}"/>
+            'is_company': True}"/>
     </function>
-
 </odoo>


### PR DESCRIPTION
In [this](https://github.com/odoo/odoo/commit/3941972dc7bba3e9a3d4497b312ff7f86a497157) commit, Odoo added a restriction between parents and child partners. They should have the same VAT or a UserError is raised.
We used the child-parent logic to group the partners created for testing the "Updated to DGI" feature in case their names were changed. In this PR I'm deleting that relation between them, and keeping the original name of the testing partners in the field "ref" and in the xml id, so if for some reason the name of the partner is changed, we can identify them through those fields values.