### PR TITLE
[FIX] l10n_uy_ux: remove visibility setting from l10n_uy_edi_type field in journal view

### DIFF
--- a/l10n_uy_ux/__manifest__.py
+++ b/l10n_uy_ux/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Localization",
     "countries": ["uy"],
     "license": "LGPL-3",
-    "version": "18.0.1.9.0",
+    "version": "18.0.1.10.0",
     "depends": [
         "l10n_uy_edi",
         "certificate",

--- a/l10n_uy_ux/views/account_journal_views.xml
+++ b/l10n_uy_ux/views/account_journal_views.xml
@@ -6,10 +6,6 @@
         <field name="name">account.journal.form</field>
         <field name="inherit_id" ref="l10n_uy_edi.view_account_journal_form_inherit_l10n_uy_edi"/>
         <field name="arch" type="xml">
-            <field name="l10n_uy_edi_type" position="attributes">
-                <attribute name="invisible">country_code != "UY" or not l10n_latam_use_documents or type not in ["sale", "purchase"]</attribute>
-                <attribute name="required">country_code == "UY" and l10n_latam_use_documents and type in ["sale", "purchase"]</attribute>
-            </field>
             <!-- TODO KZ llevar esto como fix en pr a modulo l10n_latam_invoice_document -->
             <field name="refund_sequence" position="attributes">
                 <attribute name="invisible">type not in ["sale", "purchase"] or (l10n_latam_use_documents and country_code == "UY")</attribute>


### PR DESCRIPTION
This is to prevent error on vendor bills views caused by l10n_uy_edi_type field being shown in the journal. 