### PR TITLE
[FIX] l10n_uy_edi_stock: removed dependency to avoid migration problems

### DIFF
--- a/l10n_uy_edi_stock/__manifest__.py
+++ b/l10n_uy_edi_stock/__manifest__.py
@@ -1,13 +1,12 @@
 {
     "name": """Uruguay - E-Remitos""",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.1.0",
     "category": "Accounting/Localizations/EDI",
     "countries": ["uy"],
     "sequence": 12,
     "author": "ADHOC SA",
     "depends": [
         "l10n_uy_edi",  # we needed because we extend views
-        "l10n_uy_ux",
         "stock_account",
         "sale_stock",
     ],

--- a/l10n_uy_edi_stock/models/__init__.py
+++ b/l10n_uy_edi_stock/models/__init__.py
@@ -1,5 +1,4 @@
 from . import l10n_latam_document_type
-from . import l10n_uy_addenda
 from . import l10n_uy_edi_document
 from . import stock_move
 from . import stock_picking

--- a/l10n_uy_edi_stock/models/l10n_uy_addenda.py
+++ b/l10n_uy_edi_stock/models/l10n_uy_addenda.py
@@ -1,7 +1,0 @@
-from odoo import fields, models
-
-
-class L10nUyAddenda(models.Model):
-    _inherit = "l10n_uy_edi.addenda"
-
-    apply_on = fields.Selection(selection_add=[("stock.picking", "Delivery Guide")], default="all")

--- a/l10n_uy_edi_stock/models/l10n_uy_edi_document.py
+++ b/l10n_uy_edi_stock/models/l10n_uy_edi_document.py
@@ -7,10 +7,6 @@ class L10nUyEdiDocument(models.Model):
 
     picking_id = fields.Many2one("stock.picking", readonly=True)
 
-    def _get_origin_record(self):
-        self.ensure_one()
-        return self.picking_id or super()._get_origin_record()
-
     def _get_uuid(self, origin_record):
         # EXTEND from l10n_uy_edi
         """uuid to identify picking (shortcut for testing env unicity)"""

--- a/l10n_uy_edi_stock/models/stock_move.py
+++ b/l10n_uy_edi_stock/models/stock_move.py
@@ -7,6 +7,5 @@ class StockMove(models.Model):
     l10n_uy_edi_addenda_ids = fields.Many2many(
         "l10n_uy_edi.addenda",
         string="Mandatory Disclosures",
-        domain="[('type', '=', 'item'), ('apply_on', 'in', ['all', 'stock.picking'])]",
         ondelete="restrict",
     )

--- a/l10n_uy_edi_stock/models/stock_picking.py
+++ b/l10n_uy_edi_stock/models/stock_picking.py
@@ -89,11 +89,17 @@ class StockPicking(models.Model):
         string="PDF File",
         copy=False,
     )
+    l10n_uy_edi_xml_attachment_id = fields.Many2one(
+        comodel_name="ir.attachment",
+        string="Uruguay E-Invoice XML",
+        compute="_compute_l10n_uy_edi_xml_attachment_id",
+        help="Uruguay: the most recent e-invoice XML returned by Uruware.",
+    )
 
     l10n_uy_cfe_xml = fields.Text("Technical field to preview the xml")
     manual_uruware_invoice = fields.Char()
 
-    # Compute methods
+    # Onchange methods
 
     @api.onchange("l10n_uy_transfer_of_goods")
     def onchange_transfer_of_goods(self):
@@ -103,6 +109,14 @@ class StockPicking(models.Model):
             )  # e-Delivery Guide Document
         else:
             self.l10n_latam_document_type_id = False
+
+    # Compute methods
+
+    @api.depends("l10n_uy_edi_document_id.state")
+    def _compute_l10n_uy_edi_xml_attachment_id(self):
+        for move in self:
+            doc = move.l10n_uy_edi_document_id
+            move.l10n_uy_edi_xml_attachment_id = doc.state == "accepted" and doc.attachment_id
 
     @api.depends("l10n_latam_document_number")
     def _compute_display_name(self):

--- a/l10n_uy_edi_stock/models/stock_picking.py
+++ b/l10n_uy_edi_stock/models/stock_picking.py
@@ -298,10 +298,6 @@ class StockPicking(models.Model):
                     pdf_file.register_as_main_attachment(force=True)
                     self.invalidate_recordset(fnames=["edi_pdf_report_id", "edi_pdf_report_file"])
                     res_files |= pdf_file
-                if errors := pdf_result.get("errors"):
-                    msg = _("Error getting the PDF file: %s", errors)
-                    self.l10n_uy_edi_error = (self.l10n_uy_edi_error or "") + msg
-                    self.message_post(body=msg)
         else:
             self._l10n_uy_edi_get_preview_xml()
         return res_files
@@ -355,6 +351,11 @@ class StockPicking(models.Model):
                 }
             )
             res["pdf_file"] = pdf_file
+
+        if errors := result.get("errors"):
+            msg = _("Error getting the PDF file: %s", errors)
+            self.l10n_uy_edi_error = (self.l10n_uy_edi_error or "") + msg
+            self.message_post(body=msg)
 
         return res
 

--- a/l10n_uy_edi_stock/models/stock_picking.py
+++ b/l10n_uy_edi_stock/models/stock_picking.py
@@ -116,7 +116,7 @@ class StockPicking(models.Model):
     def _compute_l10n_uy_edi_xml_attachment_id(self):
         for move in self:
             doc = move.l10n_uy_edi_document_id
-            move.l10n_uy_edi_xml_attachment_id = doc.state == "accepted" and doc.attachment_id
+            move.l10n_uy_edi_xml_attachment_id = doc.state in ["accepted", "received", "rejected"] and doc.attachment_id
 
     @api.depends("l10n_latam_document_number")
     def _compute_display_name(self):

--- a/l10n_uy_edi_stock/models/stock_picking.py
+++ b/l10n_uy_edi_stock/models/stock_picking.py
@@ -35,7 +35,6 @@ class StockPicking(models.Model):
     l10n_uy_edi_addenda_ids = fields.Many2many(
         "l10n_uy_edi.addenda",
         string="Addenda & Disclosure",
-        domain="[('type', 'in', ['issuer', 'receiver', 'cfe_doc', 'addenda']), ('apply_on', 'in', ['all', 'stock.picking'])]",
         help="Addendas and Mandatory Disclosure to add on the CFE. They can be added either to the issuer, receiver,"
         " cfe doc additional info section or to the addenda section. However, the item type should not be set in"
         " this field; instead, it should be specified in the invoice lines.",

--- a/l10n_uy_edi_stock/views/l10n_uy_edi_document_views.xml
+++ b/l10n_uy_edi_stock/views/l10n_uy_edi_document_views.xml
@@ -4,7 +4,7 @@
     <record id="l10n_uy_edi_withholding_document_view_form" model="ir.ui.view">
         <field name="name">l10n_uy_edi.document.view.form</field>
         <field name="model">l10n_uy_edi.document</field>
-        <field name="inherit_id" ref="l10n_uy_ux.l10n_uy_ux_document_view_form"/>
+        <field name="inherit_id" ref="l10n_uy_edi.l10n_uy_edi_document_view_form"/>
         <field name="arch" type="xml">
             <field name="move_id" position="after">
                 <field name="picking_id" invisible="not picking_id"/>

--- a/l10n_uy_ux/__manifest__.py
+++ b/l10n_uy_ux/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Localization",
     "countries": ["uy"],
     "license": "LGPL-3",
-    "version": "18.0.1.10.0",
+    "version": "18.0.1.11.0",
     "depends": [
         "l10n_uy_edi",
         "certificate",

--- a/l10n_uy_ux/models/l10n_uy_addenda.py
+++ b/l10n_uy_ux/models/l10n_uy_addenda.py
@@ -12,6 +12,7 @@ class L10nUyAddenda(models.Model):
         [
             ("all", "All CFE"),
             ("account.move", "Invoices and Tickets"),
+            ("stock.picking", "Delivery Guide"),
         ],
         default="account.move",
     )

--- a/l10n_uy_ux/models/l10n_uy_edi_document.py
+++ b/l10n_uy_ux/models/l10n_uy_edi_document.py
@@ -15,7 +15,11 @@ class L10nUyEdiDocument(models.Model):
 
     def _get_origin_record(self):
         self.ensure_one()
-        return self.move_id
+        if self.move_id:
+            return self.move_id
+        if hasattr(self, "picking_id") and self.picking_id:
+            return self.picking_id
+        return False
 
     def _compute_from_origin(self):
         for res in self:


### PR DESCRIPTION
Sacamos dependencia de l10n_uy_ux porque hace que no se corran los scripts pre y post-migration, y además no es necesaria ya que el módulo se autoinstala con l10n_uy_edi