### PR TITLE
[IMP] l10n_uy_ux: allow user to send custom report parameters

### DIFF
--- a/l10n_uy_ux/models/l10n_uy_edi_document.py
+++ b/l10n_uy_ux/models/l10n_uy_edi_document.py
@@ -82,6 +82,24 @@ class L10nUyEdiDocument(models.Model):
         caracteres por línea.
         Extendemos para que los usuarios puedan definir el formato de reporte a utilizar, en casos
         diferentes a los que contempla Odoo oficial.
+        Parámetros personalizados:
+        - nombreParametros: puede contener "reporte", "formato" y/o "adenda"
+        - valoresParametros: valores correspondientes respetando el orden
+        - "reporte": nombre del reporte alternativo, "codigo" para códigos de ítems, o "ingles"
+        - "formato": valor "rollo"
+        - "adenda": valor "true" para adenda en página separada
+
+        IMPORTANTE: Los valores personalizados de "reporte" (distintos de "ingles") deben ser únicos.
+        No pueden coexistir múltiples valores para el parámetro "reporte".
+
+        Ejemplos válidos:
+        - [["adenda"], ["true"]]
+        - [["reporte"], ["ingles"]]
+        - [["reporte"], ["secundario"]]
+        - [["adenda", "reporte"], ["true", "ingles"]]
+
+        Ejemplos NO válidos:
+        - [["reporte", "reporte"], ["secundario", "ingles"]]
         """
         endpoint, params = super()._get_report_params()
         user_report_params = safe_eval.safe_eval(self.company_id.l10n_uy_report_params or "[]")
@@ -94,26 +112,27 @@ class L10nUyEdiDocument(models.Model):
             | self.env.ref("l10n_uy.dc_cn_e_inv_exp")
             | self.env.ref("l10n_uy.dc_dn_e_inv_exp")
         ).mapped("code")
+
+        user_params = {}
         if user_report_params:
             if "Parametros" not in endpoint:
                 endpoint += "ConParametros"
-                params = {
-                    "nombreParametros": {"string": []},
-                    "valoresParametros": {"string": []},
-                }
-            # Si el usuario definió separar la adenda, lo agregamos a los parámetros
-            if "adenda" in user_report_params[0]:
-                params["nombreParametros"]["string"].append("adenda")
-                params["valoresParametros"]["string"].append("true")
-            # Si el usuario definió un idioma, lo agregamos a los parámetros
-            if "ingles" in user_report_params[1] and self.l10n_latam_document_type_id.code in available_doc_codes:
-                params["nombreParametros"]["string"].append("reporte")
-                params["valoresParametros"]["string"].append("ingles")
-            if "secundario" in user_report_params[1]:
-                params["nombreParametros"]["string"].append("reporte")
-                params["valoresParametros"]["string"].append("secundario")
 
-        return endpoint, params
+            user_params["nombreParametros"] = {"string": []}
+            user_params["valoresParametros"] = {"string": []}
+
+            for param_name, param_value in zip(user_report_params[0], user_report_params[1]):
+                if param_name in ["adenda", "formato", "reporte"]:
+                    if (
+                        param_name == "reporte"
+                        and param_value == "ingles"
+                        and self.l10n_latam_document_type_id.code not in available_doc_codes
+                    ):
+                        continue
+                    user_params["nombreParametros"]["string"].append(param_name)
+                    user_params["valoresParametros"]["string"].append(param_value)
+
+        return endpoint, user_params or params
 
     # Metodos nuevos
 

--- a/l10n_uy_ux/models/res_config_settings.py
+++ b/l10n_uy_ux/models/res_config_settings.py
@@ -1,6 +1,7 @@
 import pprint
 
 from odoo import api, fields, models
+from odoo.exceptions import UserError
 from odoo.tools.safe_eval import safe_eval
 
 
@@ -50,3 +51,35 @@ class ResConfigSettings(models.TransientModel):
             env_data.update({"l10n_uy_edi_ucfe_test_env": pprint.pformat(env_data)})
 
         self.company_id.write(env_data)
+
+    @api.onchange("l10n_uy_report_params")
+    def uy_ux_onchange_l10n_uy_report_params(self):
+        """Corroboramos que los valores ingresados sean válidos."""
+        if not self.l10n_uy_report_params:
+            return
+
+        if len(safe_eval(self.l10n_uy_report_params or "[]")) < 2:
+            raise UserError(
+                self.env._(
+                    "El campo debe contener al menos dos valores: nombre del parámetro y valor. Por favor, verifique que los valores fueron ingresados en el formato correcto."
+                )
+            )
+
+        param_names = safe_eval(self.l10n_uy_report_params or "[]")[0]
+        valid_params = ["adenda", "reporte", "formato"]
+        invalid_params = [param for param in param_names if param not in valid_params]
+        if invalid_params:
+            raise UserError(
+                self.env._(
+                    f"Los siguientes parámetros ingresados son inválidos: {', '.join(invalid_params)}. "
+                    f"Los valores permitidos son: {', '.join(valid_params)}."
+                )
+            )
+        reporte_values = [i for i, name in enumerate(param_names) if name == "reporte"]
+        if len(reporte_values) > 1:
+            raise UserError(
+                self.env._(
+                    "El parámetro 'reporte' contiene dos valores diferentes. "
+                    "Solo se permite un valor personalizado por parámetro 'reporte'. Por favor, verifique la configuración de sus reportes."
+                )
+            )

--- a/l10n_uy_ux/tests/__init__.py
+++ b/l10n_uy_ux/tests/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import test_l10n_uy_ux

--- a/l10n_uy_ux/tests/test_l10n_uy_ux.py
+++ b/l10n_uy_ux/tests/test_l10n_uy_ux.py
@@ -1,0 +1,122 @@
+from odoo import Command
+from odoo.addons.l10n_uy_edi.tests.common import TestUyEdi
+from odoo.exceptions import UserError
+from odoo.tests.common import tagged
+
+
+@tagged("-at_install", "post_install", "post_install_l10n", "ux")
+class TestUx(TestUyEdi):
+    @classmethod
+    def setUpClass(self):
+        super().setUpClass()
+        self.company_uy.l10n_uy_edi_ucfe_env = "demo"
+
+    def test_invalid_report_params(self):
+        with self.assertRaisesRegex(UserError, "El parámetro 'reporte' contiene dos valores diferentes."):
+            record = self.env["res.config.settings"].create(
+                {"l10n_uy_report_params": "[['reporte', 'reporte'], ['secundario', 'ingles']]"}
+            )
+            record.uy_ux_onchange_l10n_uy_report_params()
+
+    def _check_computed_params(self, value, expected_result):
+        self.company_uy.l10n_uy_report_params = value
+        invoice = self._create_move(
+            invoice_line_ids=[
+                Command.create(
+                    {
+                        "product_id": self.service_vat_22.id,
+                        "price_unit": 100.0,
+                    }
+                ),
+            ],
+        )
+
+        invoice.action_post()
+        self._send_and_print(invoice)  # to generate the l10n_uy_edi.document
+        result = invoice.l10n_uy_edi_document_id._get_report_params()
+        self.assertEqual(result, expected_result, "Error in computed report parameters")
+
+    def _check_automatic_params(self, expected_result):
+        """Check if the automatic params are correctly set"""
+        self.company_uy.l10n_uy_report_params = False
+        invoice = self._create_move(
+            invoice_line_ids=[
+                Command.create(
+                    {
+                        "product_id": self.service_vat_22.id,
+                        "price_unit": 100.0,
+                    }
+                ),
+            ],
+        )
+        line_length = 140
+        max_lines = 6
+        invoice.narration = "A" * (line_length * max_lines + 10)
+        invoice.action_post()
+        self._send_and_print(invoice)
+        result = invoice.l10n_uy_edi_document_id._get_report_params()
+        self.assertEqual(result, expected_result, "Error in automatic report parameters")
+
+    def test_without_report_params(self):
+        """If not set any param should use standar PDF"""
+        self._check_computed_params(False, ("ObtenerPdf", {}))
+        self._check_computed_params("", ("ObtenerPdf", {}))
+        self._check_computed_params("[]", ("ObtenerPdf", {}))
+
+    def test_with_report_params(self):
+        """If param set then should prepare correctly the report params to send"""
+        self._check_computed_params(
+            "[['adenda'], ['true']]",
+            (
+                "ObtenerPdfConParametros",
+                {
+                    "nombreParametros": {"string": ["adenda"]},
+                    "valoresParametros": {"string": ["true"]},
+                },
+            ),
+        )
+
+        self._check_computed_params(
+            "[['reporte'], ['ingles']]",
+            (
+                "ObtenerPdfConParametros",
+                {
+                    "nombreParametros": {"string": ["reporte"]},
+                    "valoresParametros": {"string": ["ingles"]},
+                },
+            ),
+        )
+
+        self._check_computed_params(
+            "[['reporte'], ['secundario']]",
+            (
+                "ObtenerPdfConParametros",
+                {
+                    "nombreParametros": {"string": ["reporte"]},
+                    "valoresParametros": {"string": ["secundario"]},
+                },
+            ),
+        )
+
+        self._check_computed_params(
+            "[['adenda', 'reporte'], ['true', 'ingles']]",
+            (
+                "ObtenerPdfConParametros",
+                {
+                    "nombreParametros": {"string": ["adenda", "reporte"]},
+                    "valoresParametros": {"string": ["true", "ingles"]},
+                },
+            ),
+        )
+
+    def test_with_automatic_report_params(self):
+        """If user does not set any param, it should take the automatic params from Odoo method"""
+        self._check_automatic_params(
+            (
+                "ObtenerPdfConParametros",
+                {
+                    "nombreParametros": {"string": ["adenda"]},
+                    "valoresParametros": {"string": ["true"]},
+                },
+            ),
+        )


### PR DESCRIPTION
### Descripción

Este PR corrige la funcionalidad del método que permite al usuario personalizar el reporte impreso de Uruware, asegurando que se tengan en cuenta los parámetros que el mismo usuario envía desde Odoo.
Anteriormente, los parámetros para la generación del reporte estaban hardcodeados (ej: `["adenda". "true"]`, `["reporte", "inglés"]` o `["reporte", "secundario"]`). Esto funcionaba bien para los parámetros estandar (reporte en inglés y adenda en página separada) pero para el caso del reporte personalizado sólo tenía en cuenta el caso de que el mismo sea con el valor "secundario", y existen múltiples tipos de reportes con distintos nombres.
Además, no se manejaba correctamente el caso en que se intentaban combinar valores incompatibles para el mismo parámetro (por ejemplo, ["reporte", "inglés"]` y `["reporte", "secundario"]` al mismo tiempo), lo cual producía un error en el endpoint de Uruware.

### Cambios Implementados

* Refactoricé la lógica para separar los parámetros heredados del método padre de Odoo de los que ingresa el usuario. Anteriormente, sobrescribíamos la variable `params` que traíamos del método padre, para poder agregarle los parámetros del usuario. Esto no estaba funcionando bien ya que no se eliminaban los parámetros de base y podía ocasionar duplicación de parámetros. 
Si no hay personalizaciones, se siguen enviando los parámertos que vienen del método padre de Odoo
* Agregué un mensaje de error por si el usuario ingresa dos veces el parámetro "reporte", ya que sólo puede enviarse una vez, o con un valor personalizado o con el valor "ingles".
* Agregué la posibilidad de personalizar el formato "rollo" como está en la documentación de Uruware, esto no estaba implementado, puede agregarse como no