### PR TITLE
[IMP] l10n_uy_ux: carga manual en Odoo de CFE emitido en Uruware.

### DIFF
--- a/l10n_uy_ux/__manifest__.py
+++ b/l10n_uy_ux/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Localization",
     "countries": ["uy"],
     "license": "LGPL-3",
-    "version": "18.0.1.11.0",
+    "version": "18.0.1.12.0",
     "depends": [
         "l10n_uy_edi",
         "certificate",

--- a/l10n_uy_ux/views/account_move_views.xml
+++ b/l10n_uy_ux/views/account_move_views.xml
@@ -30,13 +30,13 @@
 
             <field name="l10n_uy_edi_cfe_uuid" position="after">
 
-                <div name="from_uruwarw" colspan="2" invisible="state != 'draft' or l10n_uy_edi_journal_type != 'manual'">
-                    <div>
+                <div name="from_uruware" colspan="2" invisible="l10n_uy_edi_journal_type != 'manual'">
+                    <div  invisible="state != 'draft'">
                         <button name="uy_ux_action_get_uruware_cfe" type="object" string="Get Uruware Invoice" class="oe_link oe_inline"/>
                         <field name="manual_uruware_invoice" placeholder="Uruware UUID" class="oe_inline"/>
                     </div>
-                    <field name="l10n_uy_edi_document_id" readonly="1" class="oe_inline"/> - <field name="l10n_uy_edi_cfe_state" class="oe_inline"/>
-                    <button name="uy_ux_action_uy_get_pdf" type="object" string="(UY) Print Legal PDF" class="oe_inline oe_link" icon="fa-print" groups="base.group_no_one"/>
+                    <field name="l10n_uy_edi_document_id" readonly="1" class="oe_inline"/> - <field name="l10n_uy_edi_cfe_state" class="oe_inline" invisible="not l10n_uy_edi_document_id"/>
+                    <button name="uy_ux_action_uy_get_pdf" type="object" string="(UY) Print Legal PDF" class="oe_inline oe_link" icon="fa-print" groups="base.group_no_one" invisible="not l10n_uy_edi_document_id"/>
                 </div>
             </field>
 


### PR DESCRIPTION
Cuando se hace la carga manual de un CFE emitido en Uruware no se logra ver que el edi document quedó realmente vinculado a la factura entonces con este pr lo que hacemos es que sea visible. Además hacemos que el botón "Get Uruware Invoice" y el campo UUID sean visibles solo cuando el estado de la factura es "draft" (siempre y cuando el diario sea manual).
Ticket Adhoc side: 99007