### PR TITLE
[FIX] l10n_uy_ux: CompraID on final consumer

### DIFF
--- a/l10n_uy_ux/models/account_move.py
+++ b/l10n_uy_ux/models/account_move.py
@@ -401,6 +401,6 @@ class AccountMove(models.Model):
             .sudo()
             .search([("name", "=", "sale_require_purchase_order_number"), ("state", "in", ["installed", "to upgrade"])])
         )
-        if oca_module_installed and self.company_id.l10n_uy_edi_ucfe_env != "demo":
+        if oca_module_installed and self.company_id.l10n_uy_edi_ucfe_env != "demo" and res:
             res["CompraID"] = self.purchase_order_number and self.purchase_order_number[:50] or None
         return res


### PR DESCRIPTION
We will need to inform CompraID from a purchase order only if we are sending partner information in the receptor tag.

Currently, is trying to send the receptor tag with only the valud CompraID=None, which is returing and error in the template. Now. if there is not partner info to report then we do not need to add the tag