### PR TITLE
[FIX] l10n_uy_edi: Restore native invisibility of restrict_mode_hash_table for bank and cash journals

### DIFF
--- a/l10n_uy_edi/__manifest__.py
+++ b/l10n_uy_edi/__manifest__.py
@@ -7,7 +7,7 @@
     'author': 'ADHOC SA',
     'category': 'Localization',
     'license': 'LGPL-3',
-    'version': "16.0.1.11.0",
+    'version': "16.0.1.12.0",
     'depends': [
         'l10n_uy_account',
         'account_debit_note',

--- a/l10n_uy_edi/tests/test_check_uy_vat.py
+++ b/l10n_uy_edi/tests/test_check_uy_vat.py
@@ -10,6 +10,7 @@ class CheckUyVat(common.TransactionCase):
             'name': 'Partner uruguayo',
             'l10n_latam_identification_type_id': self.env.ref(f'l10n_uy_account.{identification_type}').id,
             'vat': vat,
+            'country_id': self.env.ref("base.uy").id
         })
 
     def test_01_uy_nie_invalid_vat(self):
@@ -33,8 +34,8 @@ class CheckUyVat(common.TransactionCase):
         self.assertEqual(partner._l10n_uy_check_nie_ci(), True)
 
     def test_05_uy_rut_invalid_vat(self):
-        # Invalid RUT
-        with self.assertRaisesRegex(ValidationError, 'Not a valid RUT/RUC'):
+        msg = "The VAT number.*does not seem to be valid"
+        with self.assertRaisesRegex(ValidationError, msg):
             partner = self._test_uy_create_partner('it_rut', '215521750018')
 
     def test_06_uy_rut_valid_vat(self):

--- a/l10n_uy_edi/tests/test_report_params.py
+++ b/l10n_uy_edi/tests/test_report_params.py
@@ -7,6 +7,15 @@ class TestL10nReportParams(common.TransactionCase):
     def setUp(self):
         super().setUp()
 
+        # Create a sale journal for tests
+        self.journal = self.env['account.journal'].create({
+            'name': 'Test Sale Journal',
+            'type': 'sale',
+            'code': 'TSJ',
+            'l10n_latam_use_documents': True,
+            'l10n_uy_type': 'electronic',
+        })
+
         lang_es = self.env['res.lang'].search([['code', '=', 'en_AR']])
         lang_en = self.env['res.lang'].search([['code', '=', 'en_US']])
         self.content = """
@@ -42,6 +51,7 @@ class TestL10nReportParams(common.TransactionCase):
         })
         self.move_2 = self.env['account.move'].create({
             'move_type': 'out_invoice',
+            'journal_id': self.journal.id,
             'l10n_latam_document_type_id': self.env.ref('l10n_uy_account.dc_e_ticket').id,
             'partner_id': partner_es.id,
             'narration': adenda,

--- a/l10n_uy_edi/views/account_journal_view.xml
+++ b/l10n_uy_edi/views/account_journal_view.xml
@@ -8,7 +8,21 @@
         <field name="arch" type="xml">
             <!-- El campo restrict_mode_hash_table en True en 18 no permite que se validen facturas de cliente electrónicas en localización uruguaya. Esto ya fue reportado a Odoo. Lo mantenemos invisible en 16 para que no haya problemas al migrar a 18 si es que en 16 tenían dicho campo establecido. Se podría borrar esto cuando odoo solucione el problema en 18 -->
             <field name="restrict_mode_hash_table" position="attributes">
-                <attribute name="attrs">{'invisible': [('country_code', '=', 'UY'), ('type', '=', 'sale'), ('l10n_uy_type', '=', 'electronic')]}</attribute>
+                <attribute name="attrs">
+                    {
+                        'invisible': [
+                            '|',
+                            '&amp;',
+                                ('country_code', '!=', 'UY'),
+                                ('type', 'in', ['bank', 'cash']),
+                            '&amp;',
+                                ('country_code', '=', 'UY'),
+                                '&amp;',
+                                    ('l10n_uy_type', '=', 'electronic'),
+                                    ('type', '=', 'sale')
+                        ]
+                    }
+                </attribute>
             </field>
         </field>
     </record>


### PR DESCRIPTION

Odoo natively sets the field `restrict_mode_hash_table` as invisible for bank and cash journals. However, this behavior was overridden by commit 20c72be367a2e93619c3b862b90c66e0aab331a8, which made the field visible for all journals, potentially leading to configuration errors.

This fix restores the original invisibility for bank and cash journals while keeping the exception for electronic customer invoices in Uruguay (type = sale, l10n_uy_type = electronic).