### PR TITLE
[FIX] l10n_uy_edi_stock: added MntNetoIVAOtra to empty values and reference field domain

### DIFF
--- a/l10n_uy_edi_stock/models/stock_picking.py
+++ b/l10n_uy_edi_stock/models/stock_picking.py
@@ -64,6 +64,7 @@ class StockPicking(models.Model):
     l10n_uy_edi_related_docs_ids = fields.Many2many(
         "l10n_uy_edi.document",
         string="Related Documents",
+        domain="[('picking_id', '!=', False), ('picking_id.partner_id', '=', partner_id), ('state', 'in', ['accepted', 'received', 'rejected'])]",
         help="Related electronic documents",
     )
 
@@ -514,10 +515,12 @@ class StockPicking(models.Model):
                 "MntNoGrv",
                 "MntNetoIvaTasaMin",
                 "MntNetoIVATasaBasica",
+                "MntNetoIVAOtra",
                 "IVATasaMin",
                 "IVATasaBasica",
                 "MntIVATasaMin",
                 "MntIVATasaBasica",
+                "MntIVAOtra",
                 "MntTotal",
                 "MontoNF",
                 "MntPagar",


### PR DESCRIPTION
- Agregamos domain al campo l10n_uy_edi_related_docs para que quede igual al de v19 (l10n_uy_edi_reference), en el que sólo podemos seleccionar e-remitos del mismo partner como doc relacionado.
- Corregimos error en el XML que quedó desactualizado con el nuevo campo MntNetoIVAOtra