### PR TITLE
[IMP] l10n_uy_ux: remove deprecated widget in account move form view

### DIFF
--- a/l10n_uy_ux/views/account_move_views.xml
+++ b/l10n_uy_ux/views/account_move_views.xml
@@ -74,10 +74,6 @@
             <button name='%(account_ux.action_account_change_currency)d' position="attributes">
                 <attribute name="invisible" add="country_code == 'UY'" separator="or"/>
             </button>
-            <!-- Hide the currency date picker widget for Uruguay -->
-            <widget name="account_pick_currency_date" position="attributes">
-                <attribute name="invisible" add="country_code == 'UY'" separator="or"/>
-            </widget>
         </field>
     </record>
 


### PR DESCRIPTION
We removed the widget in https://github.com/ingadhoc/account-financial-tools/pull/890