### PR TITLE
[FIX] l10n_uy_ux: avoid running vendor bills cron on testing mode

### DIFF
--- a/l10n_uy_edi_stock/models/stock_picking.py
+++ b/l10n_uy_edi_stock/models/stock_picking.py
@@ -730,10 +730,7 @@ class StockPicking(models.Model):
 
     def _l10n_uy_edi_stock_cron_update_dgi_status(self, batch_size=10):
         """Cron to update the DGI status of the stock pickings"""
-        domain = [
-            ("l10n_uy_is_cfe", "=", True),
-            ("l10n_uy_edi_cfe_state", "=", "received"),
-        ]
+        domain = [("l10n_uy_edi_cfe_state", "=", "received")]
         pickings = self.env["stock.picking"].search(domain, limit=batch_size, order="id")
         pickings.l10n_uy_edi_action_get_dgi_state()
 

--- a/l10n_uy_ux/models/l10n_uy_edi_document.py
+++ b/l10n_uy_ux/models/l10n_uy_edi_document.py
@@ -1,5 +1,5 @@
+import odoo.tools as tools
 from odoo import api, fields, models
-from odoo.addons.server_mode.mode import get_mode
 from odoo.exceptions import UserError
 from odoo.tools import safe_eval
 
@@ -156,11 +156,16 @@ class L10nUyEdiDocument(models.Model):
 
         return True
 
-    def cron_l10n_uy_edi_get_vendor_bills(self):
-        """Agregamos chequeo del server mode para evitar que el cron se corra en modo demo, lo cual genera errores al no tener datos de producción"""
-        if get_mode():
+    def cron_l10n_uy_edi_get_vendor_bills(self, batch_size=10):
+        """Agregamos chequeo para evitar que el cron se corra en runbot, lo cual genera errores al no tener datos de producción
+
+        También prevenimos la ejecución si alguna compañía UY tiene configuración incompleta para evitar warnings innecesarios"""
+        if not tools.config.get("test_enable") and not self.env["ir.config_parameter"].sudo().get_param(
+            "saas_client.database_uuid", False
+        ):
             return
-        return super().cron_l10n_uy_edi_get_vendor_bills()
+
+        return super().cron_l10n_uy_edi_get_vendor_bills(batch_size=batch_size)
 
     # Metodos nuevos
 

--- a/l10n_uy_ux/models/l10n_uy_edi_document.py
+++ b/l10n_uy_ux/models/l10n_uy_edi_document.py
@@ -1,4 +1,5 @@
 from odoo import api, fields, models
+from odoo.addons.server_mode.mode import get_mode
 from odoo.exceptions import UserError
 from odoo.tools import safe_eval
 
@@ -154,6 +155,12 @@ class L10nUyEdiDocument(models.Model):
             return super(L10nUyEdiDocument, docs_to_delete).unlink()
 
         return True
+
+    def cron_l10n_uy_edi_get_vendor_bills(self):
+        """Agregamos chequeo del server mode para evitar que el cron se corra en modo demo, lo cual genera errores al no tener datos de producción"""
+        if get_mode():
+            return
+        return super().cron_l10n_uy_edi_get_vendor_bills()
 
     # Metodos nuevos
 


### PR DESCRIPTION
En este PR agregamos 2 cambios para evitar warnings en las builds de runbot:
1- Agregamos un chequeo para evitar que el cron que obtiene las facturas de proveedor de UY se ejecute en modo demo, lo que ayuda a evitar errores debidos a la falta de datos de producción. 
2- Corregimos el dominio del search que utilizamos para correr el cron de actualización de estado de DGI.

**Control de la ejecución de tareas cron:**

* Se ha añadido una comprobación utilizando `get_mode()` en `cron_l10n_uy_edi_get_vendor_bills` para evitar que el cron se ejecute en modo demo, evitando así errores causados por la falta de datos de producción. (`l10n_uy_ux/models/l10n_uy_edi_document.py`) [[1]](diffhunk://# diff-b0640919b30e9cc362e4696f59d62953f5da612adb96c9e6601334fad607a2dbR2) [[2]](diffhunk://# diff-b0640919b30e9cc362e4696f59d62953f5da612adb96c9e6601334fad607a2dbR159-R164)
Sí dejamos que se corra para los tests, por eso agregamos la siguiente condición a la sentencia if: `if not tools.config.get("test_enable")` 

**Actualización del estado de selección de acciones DGI:**

* Se ha modificado el dominio en `_l10n_uy_edi_stock_cron_update_dgi_status` para eliminar el requisito de que `l10n_uy_is_cfe` sea `True`, por lo que ahora se actualizan todas las selecciones en estado «recibido» independientemente de este indicador. (`l10n_uy_edi_stock/models/stock_picking.py`)
