### PR TITLE
[FIX] l10n_uy_reports: formulario 2181 solo debe incluir facturas.

### DIFF
--- a/l10n_uy_reports/wizards/form_report_wiz.py
+++ b/l10n_uy_reports/wizards/form_report_wiz.py
@@ -49,6 +49,7 @@ class FormReportWiz(models.TransientModel):
         domain = [
             ("company_id", "=", self.company_id.id),
             ("state", "=", "posted"),
+            ("move_type", "!=", "entry"),
             ("date", ">=", self.date_from),
             ("date", "<=", self.date_to),
             ("partner_id.vat", "!=", False),


### PR DESCRIPTION
Ticket: 114808
El formulario 2181 solo debe incluir facturas, no asientos contables. El problema es que se obtenía un error al momento de generar el archivo txt del formulario 2181 porque estaba incluyendo un impuesto de retención que estaba en un asiento de e-Resguardo aplicado. En este pr lo estamos excluyendo del archivo (no incluimos impuestos de retenciones en el formulario 2181)