### PR TITLE
[IMP] l10n_uy_currency_update: suppress chart_template warning in tests

### DIFF
--- a/l10n_uy_currency_update/tests/test_l10n_uy_currency_update.py
+++ b/l10n_uy_currency_update/tests/test_l10n_uy_currency_update.py
@@ -3,6 +3,7 @@
 # directory
 ##############################################################################
 import datetime
+import logging
 from unittest.mock import patch
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
@@ -12,6 +13,7 @@ class TestL10nUyCurrencyUpdate(AccountTestInvoicingCommon):
     @classmethod
     @AccountTestInvoicingCommon.setup_chart_template("uy")
     def setUpClass(cls):
+        logging.getLogger("odoo.addons.account.models.chart_template").setLevel(logging.ERROR)
         super().setUpClass()
         cls.UYU = cls.env.ref("base.UYU")
         cls.UYI = cls.env.ref("base.UYI")


### PR DESCRIPTION
Set the logging level to ERROR for odoo.addons.account.models.chart_template in test setup to avoid spurious warnings during chart template loading in localization tests.

Change note:
Se suprime el warning de chart_template en los tests de localización uruguaya, permitiendo pipelines limpios y sin advertencias al ejecutar los tests automatizados. No afecta la funcionalidad del módulo, solo mejora la calidad del log.