### PR TITLE
[FIX] l10n_uy_ux: error permisos usuarios

### DIFF
--- a/l10n_uy_ux/models/l10n_uy_edi_document.py
+++ b/l10n_uy_ux/models/l10n_uy_edi_document.py
@@ -170,6 +170,17 @@ class L10nUyEdiDocument(models.Model):
 
         return super().cron_l10n_uy_edi_get_vendor_bills(batch_size=batch_size)
 
+    def _ucfe_ws_call(self, company, endpoint, method, *args, **kwargs):
+        # EXTEND l10n_uy_edi
+        """Al validar facturas desde _post (cualquier usuario), el company llega sin sudo.
+        Los campos de credenciales tienen groups="base.group_system", por lo que se necesita
+        elevar privilegios para acceder a ellos.
+
+        Esto es neceasrio ya que este metodo aca lo llamamos directo desde el post() en
+        Odoo Oficial lo llama desde el asistente Send and Print que ya corre con move.sudo(),
+        por eso no tenian este problema antes."""
+        return super()._ucfe_ws_call(company.sudo(), endpoint, method, *args, **kwargs)
+
     # Metodos nuevos
 
     def ux_uy_get_last_invoice_number(self, document_type):


### PR DESCRIPTION
No permite validar facturas a usuarios que tienen rol Usuario, solo estaba pudiendo validar la facturas los que tienen rol Administrador

Esto sucede aca en el modulo UX es porque el metodo que llama a validar la factura ser hace directo desde el post y no desde el wizard de send and print