### PR TITLE
[FIX] l10n_uy_ux: Expo invoice with discounts

### DIFF
--- a/l10n_uy_ux/__manifest__.py
+++ b/l10n_uy_ux/__manifest__.py
@@ -26,6 +26,7 @@
         "views/res_partner_view.xml",
         "views/l10n_uy_addenda_views.xml",
         "views/l10n_uy_edi_document_views.xml",
+        "views/cfe_template.xml",
         "security/ir.model.access.csv",
     ],
     "demo": [

--- a/l10n_uy_ux/models/account_move.py
+++ b/l10n_uy_ux/models/account_move.py
@@ -551,6 +551,25 @@ class AccountMove(models.Model):
         self.l10n_uy_edi_document_id._compute_from_origin()
         return super()._l10n_uy_edi_update_xml_and_pdf_file(response)
 
+    def _l10n_uy_edi_cfe_D_global_discount(self, tax_details):
+        # EXTENDS l10n_uy_edi
+        """Sobreescribimos para que ValorDR considere la cantidad de items en la línea."""
+        self.ensure_one()
+        res = []
+        for k, line in enumerate(self.invoice_line_ids.filtered(lambda line: line.price_unit < 0), 1):
+            invoice_ind = self._get_invoice_indicator(line, tax_details)
+            res.append(
+                {
+                    "NroLinDR": k,  # D1
+                    "TpoMovDR": "D",  # D2
+                    "TpoDR": 1,  # D3
+                    "GlosaDR": line.name[:100] if line.name else _("Discount"),  # D5
+                    "ValorDR": abs(line.price_unit * line.quantity),  # D6
+                    "IndFactDR": invoice_ind,  # D7
+                }
+            )
+        return res
+
     def _l10n_uy_edi_cfe_A_receptor(self):
         # EXTENDS: l10n_uy_edi
         """If sale_require_purchase_order_number OCA module is installed we change the value of the CompraID tag.

--- a/l10n_uy_ux/views/cfe_template.xml
+++ b/l10n_uy_ux/views/cfe_template.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="cfe_template" inherit_id="l10n_uy_edi.cfe_template">
+        <xpath expr="//MntExpoyAsim" position="replace">
+        <!-- Permitimos que el campo esté en 0 para facturas y notas de crédito/débito de exportación -->
+            <MntExpoyAsim t-if="int(cfe.l10n_latam_document_type_id.code) in [121, 122, 123]" t-out="format_float(totals_detail['MntExpoyAsim'], 2, valid_zero=1)"/>
+        </xpath>
+    </template>
+
+</odoo>


### PR DESCRIPTION
This pull request introduces an extension to the electronic invoice (CFE) handling for Uruguay, focusing on improved support for export documents and global discounts. The main changes include a new XML template to allow zero values for export amounts, an override for calculating global discounts considering line quantities, and the registration of the new template in the module manifest.

**CFE Export Document Support:**
* Added `cfe_template.xml` to allow the `<MntExpoyAsim>` field to be zero for export invoices and credit/debit notes, improving compliance with export requirements (`l10n_uy_ux/views/cfe_template.xml`, `l10n_uy_ux/__manifest__.py`). [[1]](diffhunk://#diff-ed20e87b53d7902cb27df2d531be3998f8ab1add93d4022e988439b63813b0d9R1-R11) [[2]](diffhunk://#diff-41c5a4af6ac3167645f5825f232b23d7a882a958cb62371ef76009f6d3d79003R29)

**Global Discount Calculation:**
* Introduced `_l10n_uy_edi_cfe_D_global_discount` method to compute global discounts by considering the quantity of discounted items, ensuring accurate discount values in electronic documents (`l10n_uy_ux/models/account_move.py`).