### PR TITLE
[IMP] l10n_uy_ux: hide UCFE environment selector on production

### DIFF
--- a/l10n_uy_ux/__manifest__.py
+++ b/l10n_uy_ux/__manifest__.py
@@ -13,6 +13,7 @@
         "l10n_uy_edi",
         "certificate",
         "account_ux",
+        "server_mode",
     ],
     "data": [
         "data/l10n_latam.document.type.csv",

--- a/l10n_uy_ux/models/res_config_settings.py
+++ b/l10n_uy_ux/models/res_config_settings.py
@@ -1,6 +1,7 @@
 import pprint
 
 from odoo import api, fields, models
+from odoo.addons.server_mode.mode import get_mode
 from odoo.exceptions import UserError
 from odoo.tools.safe_eval import safe_eval
 
@@ -10,6 +11,12 @@ class ResConfigSettings(models.TransientModel):
 
     l10n_uy_dgi_crt_id = fields.Many2one(related="company_id.l10n_uy_dgi_crt_id", readonly=False)
     l10n_uy_report_params = fields.Char(related="company_id.l10n_uy_report_params", readonly=False)
+    l10n_uy_edi_is_prod_db = fields.Boolean(
+        default=lambda self: not get_mode(),
+        help="Technical field. True when running on a real production database (server_mode not set)."
+        " Used to hide the UCFE environment selector, since on production the environment is always"
+        " 'production'.",
+    )
 
     @api.onchange("l10n_uy_edi_ucfe_env")
     def uy_ux_onchange_ufce_env(self):

--- a/l10n_uy_ux/views/res_config_settings_view.xml
+++ b/l10n_uy_ux/views/res_config_settings_view.xml
@@ -7,6 +7,16 @@
         <field name="inherit_id" ref="l10n_uy_edi.res_config_settings_view_form_inherit_l10n_uy_edi"/>
         <field name="arch" type="xml">
 
+            <!-- On production databases the UCFE environment is always "production",
+                 so hide the environment selector to avoid changing it by mistake. -->
+            <xpath expr="//setting[@id='uy_env']//field[@name='l10n_uy_edi_ucfe_env']" position="after">
+                <field name="l10n_uy_edi_is_prod_db" invisible="1"/>
+            </xpath>
+
+            <setting id="uy_env" position="attributes">
+                <attribute name="invisible">l10n_uy_edi_is_prod_db</attribute>
+            </setting>
+
             <setting id="uy_ucfe" position="after">
 
                 <!-- Formato de reporte -->


### PR DESCRIPTION
## Qué

En bases productivas se esconde el setting `uy_env` (selector de ambiente UCFE Web Services) en Ajustes de Contabilidad, ya que en producción `l10n_uy_edi_ucfe_env` siempre es `production` y ofrecer el selector solo invita a cambiarlo por error.

## Cómo

- Nuevo campo técnico `l10n_uy_edi_is_prod_db` en `res.config.settings`, `True` cuando `server_mode` no está seteado (base productiva real), calculado con `get_mode()` — el mismo criterio canónico que usa `saas_client_l10n_uy._check_env`.
- El setting `uy_env` queda `invisible` cuando `l10n_uy_edi_is_prod_db` es `True`.
- El setting de credenciales `uy_ucfe` sigue visible: en producción se pueden seguir editando las credenciales del proveedor UCFE.
- Se agrega `server_mode` a las dependencias del módulo.

## Tarea

Task 70261 — [19-CL/UY] Esconder campos webservices UY/CL en prod