### PR TITLE
[FIX] l10n_uy_ux: avoid splitting last word between NomItem and DscItem

### DIFF
--- a/l10n_uy_ux/models/account_move.py
+++ b/l10n_uy_ux/models/account_move.py
@@ -307,12 +307,31 @@ class AccountMove(models.Model):
     def _l10n_uy_edi_get_line_nom_and_desc(self, aml):
         """
         Sobrescribimos este método que devuelve el valor de NomItem y DscItem para cada línea del comprobante...
+
+        NomItem (B7) tiene un máximo de 80 caracteres y el resto se traslada a DscItem (B8). Para no cortar la
+        última palabra en dos (una parte en NomItem y otra en DscItem), si el límite de 80 caracteres cae dentro
+        de una palabra, esa palabra se traslada completa a la descripción. NomItem queda con longitud <= 80.
         """
         # B7 NomItem, B8 DscItem
         # Limpiamos saltos de línea que pueden romper el PDF
         clean_name = aml.name.replace("\n", " ").replace("\r", " ") if aml.name else ""
-        nom_item = clean_name[:80] or "-"
-        description = clean_name[80:] or ""
+
+        max_len = 80
+        if len(clean_name) <= max_len:
+            nom_item = clean_name
+            description = ""
+        else:
+            cut = max_len
+            # Si el corte cae dentro de una palabra (el caracter límite no es un espacio), retrocedemos hasta el
+            # último espacio para trasladar la palabra completa a la descripción.
+            if not clean_name[max_len].isspace():
+                last_space = clean_name.rfind(" ", 0, max_len)
+                if last_space != -1:
+                    cut = last_space + 1
+            nom_item = clean_name[:cut]
+            description = clean_name[cut:]
+
+        nom_item = nom_item or "-"
 
         if aml.l10n_uy_edi_addenda_ids:
             adenda = [

--- a/l10n_uy_ux/tests/test_l10n_uy_ux.py
+++ b/l10n_uy_ux/tests/test_l10n_uy_ux.py
@@ -183,11 +183,14 @@ class TestUx(TestUyEdi):
                 self.assertEqual(nom_item, "Custom Description"[:80], "NomItem mismatch for line with description")
                 self.assertEqual(description, "", "Description mismatch for line with description")
             elif idx == 2:  # +80 chars without description
+                # El corte de 80 cae dentro de la palabra "chars", por lo que se traslada completa a la descripción
                 self.assertEqual(
-                    nom_item, long_name[:80], "NomItem mismatch for line with long name without description"
+                    nom_item,
+                    "Product name for testing purposes that intentionally contains more than eighty ",
+                    "NomItem mismatch for line with long name without description",
                 )
                 self.assertEqual(
-                    description, long_name[80:], "Description mismatch for line with long name without description"
+                    description, "chars", "Description mismatch for line with long name without description"
                 )
             elif idx == 3:  # +80 chars with custom description (aml.name is the custom description)
                 self.assertEqual(
@@ -199,7 +202,11 @@ class TestUx(TestUyEdi):
                     "Description mismatch for line with long name and description",
                 )
             elif idx == 4:  # +80 chars with addenda
-                self.assertEqual(nom_item, long_name[:80], "NomItem mismatch for line with long name and addenda")
+                self.assertEqual(
+                    nom_item,
+                    "Product name for testing purposes that intentionally contains more than eighty ",
+                    "NomItem mismatch for line with long name and addenda",
+                )
                 self.assertIn(
                     "Addenda Content", description, "Addenda content missing in description for line with addenda"
                 )
@@ -218,3 +225,46 @@ class TestUx(TestUyEdi):
             elif idx == 6 or idx == 7:  # With description deleted by user or "" (aml.name is False or empty)
                 self.assertEqual(nom_item, "-", "NomItem mismatch for line with deleted description")
                 self.assertEqual(description, "", "Description mismatch for line with deleted description")
+
+    def test_120_nom_item_does_not_split_last_word(self):
+        """NomItem no debe cortar la última palabra en dos: si el límite de 80 caracteres cae dentro de una
+        palabra, esa palabra se traslada completa a la descripción (DscItem). NomItem queda con longitud <= 80."""
+        product = self.env["product.product"].create({"name": "Simple Product"})
+
+        # El name limpio (sin saltos de línea) es:
+        # "Premium Package Marketing services for Global Retail Partners Inc Contract ABC 728 - ..."
+        # Un corte ingenuo en el caracter 80 partiría "728" en "7" | "28"; en cambio debe trasladarse completo.
+        line_name = (
+            "Premium Package\n"
+            "Marketing services for Global Retail Partners Inc\n"
+            "Contract ABC 728 - SUMMER LAUNCH EVENT - Enero 2028 "
+        )
+
+        invoice = self._create_move(
+            invoice_line_ids=[
+                Command.create(
+                    {
+                        "product_id": product.id,
+                        "name": line_name,
+                        "price_unit": 100.0,
+                    }
+                ),
+            ],
+        )
+        line = invoice.invoice_line_ids[0]
+
+        nom_item, description = invoice._l10n_uy_edi_get_line_nom_and_desc(line)
+
+        self.assertLessEqual(len(nom_item), 80, "NomItem no debe superar los 80 caracteres")
+        self.assertEqual(
+            nom_item,
+            "Premium Package Marketing services for Global Retail Partners Inc Contract ABC ",
+            "NomItem no debe cortar la última palabra en dos",
+        )
+        self.assertEqual(
+            description,
+            "728 - SUMMER LAUNCH EVENT - Enero 2028 ",
+            "La palabra que excede el máximo debe trasladarse completa a la descripción",
+        )
+        # La concatenación de NomItem + DscItem debe reconstruir el nombre limpio original
+        self.assertEqual(nom_item + description, line_name.replace("\n", " "))


### PR DESCRIPTION
## Qué cambia

En `l10n_uy_ux`, el método `_l10n_uy_edi_get_line_nom_and_desc` (que arma **NomItem** (B7) y **DscItem** (B8) de cada línea del CFE) truncaba el nombre de la línea con un slice duro en el caracter 80. Cuando el corte caía **dentro de una palabra**, la partía en dos: una parte quedaba en NomItem y el resto en la descripción.

Ahora, si el corte de 80 caracteres cae dentro de una palabra, esa palabra se traslada **completa** a la descripción (DscItem). NomItem nunca corta una palabra y mantiene una longitud `<= 80`.

## Detalle técnico

- Si `clean_name` tiene `<= 80` caracteres → todo va a NomItem, DscItem queda vacío (comportamiento previo).
- Si supera 80 y el corte cae en medio de una palabra (el caracter límite y el siguiente no son espacios), se retrocede hasta el último espacio dentro de los primeros 80 caracteres y la palabra que excede se traslada entera a DscItem.
- Caso degenerado (una única palabra de más de 80 caracteres sin espacios): se mantiene el corte duro en 80 para no dejar NomItem vacío.
- El manejo de addendas en la descripción no cambia.

## Test plan

- Se actualiza `test_110_account_move_line_nom_and_desc` para reflejar que un nombre largo ya no parte la última palabra.
- Se agrega `test_120_nom_item_does_not_split_last_word`, que valida:
  - `len(nom_item) <= 80`,
  - que la última palabra no se corta,
  - que la palabra excedente se traslada completa a la descripción,
  - que `nom_item + description` reconstruye el nombre limpio original.

Ambos tests pasan localmente (`--test-tags=/l10n_uy_ux:TestUx`).