### PR TITLE
[FIX] l10n_uy_ux: friendly error when CFE key is not found in Uruware

### DIFF
--- a/l10n_uy_ux/i18n/es.po
+++ b/l10n_uy_ux/i18n/es.po
@@ -410,6 +410,20 @@ msgstr ""
 
 #. module: l10n_uy_ux
 #. odoo-python
+#: code:addons/l10n_uy_ux/models/account_move.py:0
+msgid ""
+"No CFE was found in Uruware for the key '%s'. Please check that the "
+"'Uruware UUID' field contains the CFE key assigned in Uruware (for "
+"documents issued from Odoo it looks like 'account.move-12345'), not the "
+"document number."
+msgstr ""
+"No se encontró un CFE en Uruware para la clave '%s'. Verifique que el campo "
+"'Uruware UUID' contenga la clave del CFE asignada en Uruware (para "
+"documentos emitidos desde Odoo tiene la forma 'account.move-12345'), no el "
+"número de documento."
+
+#. module: l10n_uy_ux
+#. odoo-python
 #: code:addons/l10n_uy_ux/wizards/res_partner_update_from_padron_uy_wizard.py:0
 msgid "No partner with RUT was found to update"
 msgstr ""

--- a/l10n_uy_ux/i18n/es_419.po
+++ b/l10n_uy_ux/i18n/es_419.po
@@ -367,6 +367,20 @@ msgstr "Nuevo Valor"
 
 #. module: l10n_uy_ux
 #. odoo-python
+#: code:addons/l10n_uy_ux/models/account_move.py:0
+msgid ""
+"No CFE was found in Uruware for the key '%s'. Please check that the "
+"'Uruware UUID' field contains the CFE key assigned in Uruware (for "
+"documents issued from Odoo it looks like 'account.move-12345'), not the "
+"document number."
+msgstr ""
+"No se encontró un CFE en Uruware para la clave '%s'. Verifique que el campo "
+"'Uruware UUID' contenga la clave del CFE asignada en Uruware (para "
+"documentos emitidos desde Odoo tiene la forma 'account.move-12345'), no el "
+"número de documento."
+
+#. module: l10n_uy_ux
+#. odoo-python
 #: code:addons/l10n_uy_ux/wizards/res_partner_update_from_padron_uy_wizard.py:0
 #, python-format
 msgid "No partner with RUT was found to update"

--- a/l10n_uy_ux/models/account_move.py
+++ b/l10n_uy_ux/models/account_move.py
@@ -248,6 +248,16 @@ class AccountMove(models.Model):
                 uy_doc_code = response.findtext(".//{*}TipoCfe")
                 serie = response.findtext(".//{*}Serie")
                 doc_number = response.findtext(".//{*}NumeroCfe")
+                if not serie or not doc_number:
+                    raise UserError(
+                        self.env._(
+                            "No CFE was found in Uruware for the key '%s'. Please check that the"
+                            " 'Uruware UUID' field contains the CFE key assigned in Uruware"
+                            " (for documents issued from Odoo it looks like 'account.move-12345'),"
+                            " not the document number.",
+                            move.manual_uruware_invoice,
+                        )
+                    )
                 move.write(
                     {
                         "l10n_latam_document_number": serie + "%07d" % int(doc_number),


### PR DESCRIPTION
When linking a manually issued CFE with the "Get Uruware Invoice" button, if the key loaded in the *Uruware UUID* field does not match any CFE in Uruware, the 360 inbox response comes back without `Serie`/`NumeroCfe` and the user got a cryptic traceback:

    ValueError: invalid literal for int() with base 10: ''

This happens typically when the user loads the document number (or the bare move id) instead of the CFE key assigned in Uruware (`account.move-<id>` for documents issued from Odoo).

Now the response is validated and a clear `UserError` is raised explaining what the field expects. Spanish translations added to `es.po` / `es_419.po`.

**Test plan**

1. Invoice on a manual EDI journal, load a non-existent key in *Uruware UUID* (e.g. a bare number) and click *Get Uruware Invoice* → friendly error instead of traceback.
2. Load a valid CFE key → document is linked as before.
